### PR TITLE
Correctie vullen code bij buitenlandse plaats

### DIFF
--- a/features/bevragen/persoon/geboorte/dev/buitenlandse-plaats-gba.feature
+++ b/features/bevragen/persoon/geboorte/dev/buitenlandse-plaats-gba.feature
@@ -1,0 +1,25 @@
+#language: nl
+
+Functionaliteit: Buitenlandse geboorteplaats of locatie
+
+  Rule: wanneer de waarde voor een geboorteplaats(03.20) geen valide gemeentecode bevat wordt de plaats geleverd in de omschrijving en wordt veld code niet geleverd
+    - een valide gemeentecode bestaat uit vier cijfers en komt voor in de landelijke tabel Gemeenten
+
+    Abstract Scenario: Geboorteplaats is een <omschrijving>
+      Gegeven de persoon met burgerservicenummer '000000280' heeft de volgende gegevens
+      | geboorteplaats (03.20) |
+      | <geboorteplaats>       |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000280                       |
+      | fields              | geboorte.plaats                 |
+      Dan heeft de response een persoon met alleen de volgende 'geboorte' gegevens
+      | naam                | waarde           |
+      | plaats.omschrijving | <geboorteplaats> |
+
+      Voorbeelden:
+      | geboorteplaats     | omschrijving                    |
+      | Berlijn            | buitenlandse plaatsnaam         |
+      | 52°2'43N4°22'39"O  | locatieaanduiding               |
+      | A.B. Pakjesboot 12 | locatie aan boord van een schip |

--- a/features/bevragen/persoon/overlijden/dev/buitenlandse-plaats-gba.feature
+++ b/features/bevragen/persoon/overlijden/dev/buitenlandse-plaats-gba.feature
@@ -1,0 +1,25 @@
+#language: nl
+
+Functionaliteit: Buitenlandse overlijdensplaats of locatie
+
+  Rule: wanneer de waarde voor een plaats overlijden (08.20) geen valide gemeentecode bevat wordt de plaats geleverd in de omschrijving en wordt veld code niet geleverd
+    - een valide gemeentecode bestaat uit vier cijfers en komt voor in de landelijke tabel Gemeenten
+
+    Abstract Scenario: Overlijdensplaats is een <omschrijving>
+      Gegeven de persoon met burgerservicenummer '000000280' heeft de volgende 'overlijden' gegevens
+      | plaats overlijden (08.20) |
+      | <overlijdensplaats>       |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000280                       |
+      | fields              | overlijden.plaats               |
+      Dan heeft de response een persoon met alleen de volgende 'overlijden' gegevens
+      | naam                | waarde              |
+      | plaats.omschrijving | <overlijdensplaats> |
+
+      Voorbeelden:
+      | overlijdensplaats | omschrijving                    |
+      | Berlijn           | buitenlandse plaatsnaam         |
+      | 52°2'43N4°22'39"O | locatieaanduiding               |
+      | A.B. Titanic      | locatie aan boord van een schip |

--- a/features/bevragen/persoon/partner/dev/buitenlandse-plaats-gba.feature
+++ b/features/bevragen/persoon/partner/dev/buitenlandse-plaats-gba.feature
@@ -1,0 +1,47 @@
+#language: nl
+
+Functionaliteit: Buitenlandse geboorteplaats of locatie
+
+  Rule: wanneer de waarde voor een geboorteplaats(03.20) geen valide gemeentecode bevat wordt de plaats geleverd in de omschrijving en wordt veld code niet geleverd
+    - een valide gemeentecode bestaat uit vier cijfers en komt voor in de landelijke tabel Gemeenten
+
+    Abstract Scenario: Geboorteplaats is een <omschrijving>
+      Gegeven de persoon met burgerservicenummer '000000012' heeft een 'partner' met de volgende gegevens
+      | naam                   | waarde           |
+      | geboorteplaats (03.20) | <geboorteplaats> |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000012                       |
+      | fields              | partners.geboorte.plaats        |
+      Dan heeft de response een persoon met een 'partner' met alleen de volgende 'geboorte' gegevens
+      | naam                | waarde           |
+      | plaats.omschrijving | <geboorteplaats> |
+
+      Voorbeelden:
+      | geboorteplaats      | omschrijving                    |
+      | Berlijn             | buitenlandse plaatsnaam         |
+      | 52°2'43N4°22'39"O   | locatieaanduiding               |
+      | A.B. USS Enterprise | locatie aan boord van een schip |
+
+  Rule: wanneer de waarde voor een plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) geen valide gemeentecode bevat wordt de plaats geleverd in de omschrijving en wordt veld code niet geleverd
+    - een valide gemeentecode bestaat uit vier cijfers en komt voor in de landelijke tabel Gemeenten
+
+    Abstract Scenario: Plaats aangaan huwelijk/partnerschap is een <omschrijving>
+      Gegeven de persoon met burgerservicenummer '000000012' heeft een 'partner' met de volgende gegevens
+      | naam                                                                | waarde            |
+      | plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) | <plaats huwelijk> |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                                      |
+      | type                | RaadpleegMetBurgerservicenummer             |
+      | burgerservicenummer | 000000012                                   |
+      | fields              | partners.aangaanHuwelijkPartnerschap.plaats |
+      Dan heeft de response een persoon met een 'partner' met alleen de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam                | waarde           |
+      | plaats.omschrijving | <plaats huwelijk> |
+
+      Voorbeelden:
+      | plaats huwelijk         | omschrijving                    |
+      | Berlijn                 | buitenlandse plaatsnaam         |
+      | 0,27729° Z, 73,41797° O | locatieaanduiding               |
+      | A.B. Black Pearl        | locatie aan boord van een schip |

--- a/features/gba-dev/waardetabel-gba.feature
+++ b/features/gba-dev/waardetabel-gba.feature
@@ -213,11 +213,11 @@ Functionaliteit: Waardetabel met code en omschrijving
         | land vanwaar ingeschreven (14.10) | Landen              | immigratie                   | landVanwaarIngeschreven | 1234   |
         # In het laatste voorbeeld zou eigenlijk de "groep" immigratie moeten zijn. Echter is dit nog niet geïmplementeerd in de automation code. Als dit correct geïmplementeerd is kan de kolom "fields" vervallen en kan daarvoer "groep" gebruikt worden
 
-        Rule: wanneer de waarde voor een geboorteplaats(03.20) of een overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) geen valide gemeentecode bevat wordt de de code geleverd in zowel de code als de omschrijving
-          - een valide gemeentecode bestaat uit vier cijfers en komt voor in de landelijke tabel Gemeenten
-          - als er in de geboorteplaats (03.20) of de overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) een waarde staat die niet voorkomt in de landelijke tabel Gemeenten
-            dan wordt de waarde die in de plaats staat in zowel de code als de omschrijving opgenomen. (Buitenlandse plaatsnaam of coördinaten)
-
+  Rule: wanneer de waarde voor een geboorteplaats(03.20) of een overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) geen valide gemeentecode bevat wordt de plaats geleverd in de omschrijving en wordt veld code niet geleverd
+    - een valide gemeentecode bestaat uit vier cijfers en komt voor in de landelijke tabel Gemeenten
+    - als er in de geboorteplaats (03.20) of de overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) een waarde staat die niet voorkomt in de landelijke tabel Gemeenten
+      dan wordt de waarde die in de plaats staat in aleen de omschrijving opgenomen. (Buitenlandse plaatsnaam of coördinaten)
+      
       Scenario: Plaats is buitenlandse plaats of locatie bij code voor geboorteplaats (Als de code niet voorkomt in tabel gemeenten)
         Gegeven de persoon met burgerservicenummer '000000280' heeft de volgende gegevens
         | geboorteplaats (03.20) |
@@ -229,7 +229,6 @@ Functionaliteit: Waardetabel met code en omschrijving
         | fields              | geboorte.plaats                 |
         Dan heeft de response een persoon met alleen de volgende 'geboorte' gegevens
         | naam                | waarde   |
-        | plaats.code         | Berlijn  |
         | plaats.omschrijving | Berlijn  |
 
       Scenario: Plaats is buitenlandse plaats of locatie bij code voor Overlijden
@@ -243,7 +242,6 @@ Functionaliteit: Waardetabel met code en omschrijving
         | fields              | overlijden.plaats                  |
         Dan heeft de response een persoon met alleen de volgende 'overlijden' gegevens
         | naam                | waarde            |
-        | plaats.code         | 51° N.B. 4° O.L.  |
         | plaats.omschrijving | 51° N.B. 4° O.L.  |
 
 
@@ -258,7 +256,6 @@ Functionaliteit: Waardetabel met code en omschrijving
         | fields              | <fields>.<groep>                |
         Dan heeft de response een persoon met een '<relatiedan>' met de volgende '<groep>' gegevens
         | naam                | waarde   |
-        | plaats.code         | <waarde> |
         | plaats.omschrijving | <waarde> |
 
         Voorbeelden:

--- a/features/gba-dev/waardetabel-gba.feature
+++ b/features/gba-dev/waardetabel-gba.feature
@@ -216,7 +216,7 @@ Functionaliteit: Waardetabel met code en omschrijving
   Rule: wanneer de waarde voor een geboorteplaats(03.20) of een overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) geen valide gemeentecode bevat wordt de plaats geleverd in de omschrijving en wordt veld code niet geleverd
     - een valide gemeentecode bestaat uit vier cijfers en komt voor in de landelijke tabel Gemeenten
     - als er in de geboorteplaats (03.20) of de overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) een waarde staat die niet voorkomt in de landelijke tabel Gemeenten
-      dan wordt de waarde die in de plaats staat in aleen de omschrijving opgenomen. (Buitenlandse plaatsnaam of coördinaten)
+      dan wordt de waarde die in de plaats staat in alleen de omschrijving opgenomen. (Buitenlandse plaatsnaam of coördinaten)
       
       Scenario: Plaats is buitenlandse plaats of locatie bij code voor geboorteplaats (Als de code niet voorkomt in tabel gemeenten)
         Gegeven de persoon met burgerservicenummer '000000280' heeft de volgende gegevens

--- a/features/waardetabel.feature
+++ b/features/waardetabel.feature
@@ -256,7 +256,7 @@ Functionaliteit: Waardetabel met code en omschrijving
   Rule: wanneer de waarde voor een geboorteplaats(03.20) of een overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) geen valide gemeentecode bevat wordt de plaats geleverd in de omschrijving en wordt veld code niet geleverd
     - een valide gemeentecode bestaat uit vier cijfers en komt voor in de landelijke tabel Gemeenten
     - als er in de geboorteplaats (03.20) of de overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) een waarde staat die niet voorkomt in de landelijke tabel Gemeenten
-      dan wordt de waarde die in de plaats staat in aleen de omschrijving opgenomen. (Buitenlandse plaatsnaam of coördinaten)
+      dan wordt de waarde die in de plaats staat in alleen de omschrijving opgenomen. (Buitenlandse plaatsnaam of coördinaten)
 
     Scenario: Plaats is buitenlandse plaats of locatie bij geboorteplaats (Als de code niet voorkomt in tabel gemeenten)
       Gegeven de persoon met burgerservicenummer '000000280' heeft de volgende gegevens

--- a/features/waardetabel.feature
+++ b/features/waardetabel.feature
@@ -253,12 +253,12 @@ Functionaliteit: Waardetabel met code en omschrijving
       | land adres buitenland (13.10)     | Landen              | verblijfplaats               | verblijfadres.land      | 1234   | VerblijfplaatsBuitenland |
       | land vanwaar ingeschreven (14.10) | Landen              | immigratie                   | landVanwaarIngeschreven | 1234   |                          |
 
-  Rule: wanneer de waarde voor een geboorteplaats(03.20) of een overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) geen valide gemeentecode bevat wordt de de code geleverd in zowel de code als de omschrijving
+  Rule: wanneer de waarde voor een geboorteplaats(03.20) of een overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) geen valide gemeentecode bevat wordt de plaats geleverd in de omschrijving en wordt veld code niet geleverd
     - een valide gemeentecode bestaat uit vier cijfers en komt voor in de landelijke tabel Gemeenten
     - als er in de geboorteplaats (03.20) of de overlijdenplaats (08.20) of plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) een waarde staat die niet voorkomt in de landelijke tabel Gemeenten
-      dan wordt de waarde die in de plaats staat in zowel de code als de omschrijving opgenomen. (Buitenlandse plaatsnaam of coördinaten)
+      dan wordt de waarde die in de plaats staat in aleen de omschrijving opgenomen. (Buitenlandse plaatsnaam of coördinaten)
 
-    Scenario: Plaats is buitenlandse plaats of locatie bij code voor geboorteplaats (Als de code niet voorkomt in tabel gemeenten)
+    Scenario: Plaats is buitenlandse plaats of locatie bij geboorteplaats (Als de code niet voorkomt in tabel gemeenten)
       Gegeven de persoon met burgerservicenummer '000000280' heeft de volgende gegevens
       | geboorteplaats (03.20) |
       | Berlijn                |
@@ -269,10 +269,9 @@ Functionaliteit: Waardetabel met code en omschrijving
       | fields              | geboorte.plaats                 |
       Dan heeft de response een persoon met alleen de volgende 'geboorte' gegevens
       | naam                | waarde   |
-      | plaats.code         | Berlijn  |
       | plaats.omschrijving | Berlijn  |
 
-    Scenario: Plaats is buitenlandse plaats of locatie bij code voor Overlijden
+    Scenario: Plaats is buitenlandse plaats of locatie bij plaats voor Overlijden
       Gegeven de persoon met burgerservicenummer '000000292' heeft de volgende 'overlijden' gegevens
       | plaats overlijden (08.20) |
       | 51° N.B. 4° O.L.          |
@@ -284,7 +283,6 @@ Functionaliteit: Waardetabel met code en omschrijving
       Dan heeft de response een persoon met alleen de volgende 'overlijden' gegevens
       | naam                | waarde            |
       | indicatieOverleden  | true              |
-      | plaats.code         | 51° N.B. 4° O.L.  |
       | plaats.omschrijving | 51° N.B. 4° O.L.  |
 
 
@@ -299,7 +297,6 @@ Functionaliteit: Waardetabel met code en omschrijving
       | fields              | <fields>.<groep>                |
       Dan heeft de response een persoon met een '<relatiedan>' met de volgende '<groep>' gegevens
       | naam                | waarde   |
-      | plaats.code         | <waarde> |
       | plaats.omschrijving | <waarde> |
 
       Voorbeelden:


### PR DESCRIPTION
Correctie van de manier waarop bij een buitenlandse plaats of locatieaanduiding het veld plaats wordt gevuld.

Bij een waardetabel moet het veld code altijd een echte code uit de waardetabel bevatten. Voor een plaats kan de bron naast een code ook een vrije omschrijving bevatten. Die moet alleen in omschrijving worden gezet en niet (ook) in code.

De wijziging aan de waardetabel feature die op 9 november is gedaan wordt hiermee ongedaan gemaakt.
