### PR TITLE
Toevoegen punt aan einde van elke fout detail regel voor autorisatie

### DIFF
--- a/features/bevragen/autorisatie-gba.feature
+++ b/features/bevragen/autorisatie-gba.feature
@@ -84,9 +84,9 @@ Functionaliteit: autorisatie voor het gebruik van de API
       En de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
       | gemeente van inschrijving (09.10) |
       | 0599                              |
-       En de 'verblijfplaats' heeft de volgende 'adres' gegevens
-      | gemeente_code | identificatiecode nummeraanduiding (11.90) |
-      | 0599          | 0599200000219679                           |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0599                 | 0599200000219679                           |
       Als gba personen wordt gezocht met de volgende parameters
       | naam                          | waarde                               |
       | type                          | ZoekMetNummeraanduidingIdentificatie |
@@ -571,8 +571,8 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | gemeente van inschrijving (09.10) |
       | 0599                              |
       En de 'verblijfplaats' heeft de volgende 'adres' gegevens
-      | gemeente_code | identificatiecode nummeraanduiding (11.90) |
-      | 0599          | 0599200000219679                           |
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0599                 | 0599200000219679                           |
       Als gba personen wordt gezocht met de volgende parameters
       | naam                          | waarde                               |
       | type                          | ZoekMetNummeraanduidingIdentificatie |
@@ -601,8 +601,8 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | gemeente van inschrijving (09.10) | functie adres (10.10) |
       | 0599                              | W                     |
       En de 'verblijfplaats' heeft de volgende 'adres' gegevens
-      | gemeente_code                | 0599            |
-      | straatnaam (11.10)           | Borgesiusstraat |
+      | gemeentecode (92.10) | 0599            |
+      | straatnaam (11.10)   | Borgesiusstraat |
       Als gba personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -630,8 +630,9 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | gemeente van inschrijving (09.10) | functie adres (10.10) |
       | 0599                              | W                     |
       En de 'verblijfplaats' heeft de volgende 'adres' gegevens
-      | gemeente_code                | 0599            |
-      | straatnaam (11.10)           | Borgesiusstraat |
+      | naam                 | waarde          |
+      | gemeentecode (92.10) | 0599            |
+      | straatnaam (11.10)   | Borgesiusstraat |
       Als gba personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -655,8 +656,9 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | gemeente van inschrijving (09.10) | functie adres (10.10) |
       | 0599                              | W                     |
       En de 'verblijfplaats' heeft de volgende 'adres' gegevens
-      | gemeente_code                | 0599            |
-      | straatnaam (11.10)           | Borgesiusstraat |
+      | naam                 | waarde          |
+      | gemeentecode (92.10) | 0599            |
+      | straatnaam (11.10)   | Borgesiusstraat |
       Als personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |

--- a/features/bevragen/autorisatie-gba.feature
+++ b/features/bevragen/autorisatie-gba.feature
@@ -155,7 +155,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: geboorte.plaats.                       |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -181,7 +180,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: geboorte.plaats, geboorte.land.        |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -207,7 +205,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: <fields>.                              |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -241,7 +238,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: <fields>.                              |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -273,7 +269,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                  |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.      |
       | status   | 403                                                                          |
-      | detail   | De foutieve fields waarden zijn: partners.aangaanHuwelijkPartnerschap.datum. |
       | code     | authorization                                                                |
       | instance | /haalcentraal/api/brp/personen                                               |
 
@@ -299,7 +294,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: nationaliteiten.nationaliteit.         |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -326,7 +320,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: geslacht.                              |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -357,7 +350,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: ouders.ouderAanduiding.                |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -482,7 +474,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: partners.geslacht.                     |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -524,7 +515,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: geslacht.                              |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -613,7 +603,6 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 

--- a/features/bevragen/autorisatie-gba.feature
+++ b/features/bevragen/autorisatie-gba.feature
@@ -155,7 +155,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: geboorte.plaats                        |
+      | detail   | De foutieve fields waarden zijn: geboorte.plaats.                       |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -181,7 +181,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: geboorte.plaats, geboorte.land         |
+      | detail   | De foutieve fields waarden zijn: geboorte.plaats, geboorte.land.        |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -207,7 +207,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: <fields>                               |
+      | detail   | De foutieve fields waarden zijn: <fields>.                              |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -241,7 +241,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: <fields>                               |
+      | detail   | De foutieve fields waarden zijn: <fields>.                              |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -269,13 +269,13 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | burgerservicenummer | 000000024                                                              |
       | fields              | partners.naam.geslachtsnaam,partners.aangaanHuwelijkPartnerschap.datum |
       Dan heeft de response een object met de volgende gegevens
-      | naam     | waarde                                                                      |
-      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                 |
-      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.     |
-      | status   | 403                                                                         |
-      | detail   | De foutieve fields waarden zijn: partners.aangaanHuwelijkPartnerschap.datum |
-      | code     | authorization                                                               |
-      | instance | /haalcentraal/api/brp/personen                                              |
+      | naam     | waarde                                                                       |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                  |
+      | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden.      |
+      | status   | 403                                                                          |
+      | detail   | De foutieve fields waarden zijn: partners.aangaanHuwelijkPartnerschap.datum. |
+      | code     | authorization                                                                |
+      | instance | /haalcentraal/api/brp/personen                                               |
 
     @fout-case
     Scenario: Afnemer zonder autorisatie bijzonder Nederlanderschap vraagt om een gegeven van nationaliteit van persoon met Nederlandse nationaliteit
@@ -299,7 +299,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: nationaliteiten.nationaliteit          |
+      | detail   | De foutieve fields waarden zijn: nationaliteiten.nationaliteit.         |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -326,7 +326,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: geslacht                               |
+      | detail   | De foutieve fields waarden zijn: geslacht.                              |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -357,7 +357,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: ouders.ouderAanduiding                 |
+      | detail   | De foutieve fields waarden zijn: ouders.ouderAanduiding.                |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -482,7 +482,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: partners.geslacht                      |
+      | detail   | De foutieve fields waarden zijn: partners.geslacht.                     |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -524,7 +524,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: geslacht                               |
+      | detail   | De foutieve fields waarden zijn: geslacht.                              |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -613,7 +613,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres            |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 

--- a/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/autorisatie-gba.feature
@@ -96,7 +96,7 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
     Scenario: Afnemer vraagt om adressering.adresregel2 en heeft de daarvoor minimale autorisatie
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
       | Rubrieknummer ad hoc (35.95.60)                             | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10240 10310 90910 81110 81120 81160 81170 81210 81310 81340 | N                        | 20201128                |
+      | 10240 10310 80910 81110 81120 81160 81170 81210 81310 81340 | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
       | naam         | waarde |
       | afnemerID    | 000008 |
@@ -143,19 +143,19 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
 
       Voorbeelden:
       | ad hoc rubrieken                                      | missende autorisatie            |
-      | 10240 10310 81110 81120 81160 81170 81210 81310 81340 | gemeenteVanInschrijving (90910) |
-      | 10240 10310 90910 81120 81160 81170 81210 81310 81340 | korteStraatnaam (81110)         |
-      | 10240 10310 90910 81110 81160 81170 81210 81310 81340 | huisnummer (81120)              |
-      | 10240 10310 90910 81110 81120 81170 81210 81310 81340 | postcode (81160)                |
-      | 10240 10310 90910 81110 81120 81160 81210 81310 81340 | woonplaats (81170)              |
-      | 10240 10310 90910 81110 81120 81160 81170 81310 81340 | locatiebeschrijving (81210)     |
-      | 10240 10310 90910 81110 81120 81160 81170 81210 81340 | land (81310)                    |
-      | 10240 10310 90910 81110 81120 81160 81170 81210 81310 | regel2 (81340)                  |
+      | 10240 10310 81110 81120 81160 81170 81210 81310 81340 | gemeenteVanInschrijving (80910) |
+      | 10240 10310 80910 81120 81160 81170 81210 81310 81340 | korteStraatnaam (81110)         |
+      | 10240 10310 80910 81110 81160 81170 81210 81310 81340 | huisnummer (81120)              |
+      | 10240 10310 80910 81110 81120 81170 81210 81310 81340 | postcode (81160)                |
+      | 10240 10310 80910 81110 81120 81160 81210 81310 81340 | woonplaats (81170)              |
+      | 10240 10310 80910 81110 81120 81160 81170 81310 81340 | locatiebeschrijving (81210)     |
+      | 10240 10310 80910 81110 81120 81160 81170 81210 81340 | land (81310)                    |
+      | 10240 10310 80910 81110 81120 81160 81170 81210 81310 | regel2 (81340)                  |
 
     Scenario: Afnemer vraagt om adresseringBinnenland.adresregel2 en heeft de daarvoor minimale autorisatie
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
       | Rubrieknummer ad hoc (35.95.60)                 | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10240 10310 90910 81110 81120 81160 81170 81210 | N                        | 20201128                |
+      | 10240 10310 80910 81110 81120 81160 81170 81210 | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
       | naam         | waarde |
       | afnemerID    | 000008 |

--- a/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/autorisatie-gba.feature
@@ -60,7 +60,6 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel1.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -139,7 +138,6 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel2.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -215,7 +213,6 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel3.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -260,7 +257,6 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.land.                      |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 

--- a/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/autorisatie-gba.feature
@@ -60,7 +60,7 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel1                |
+      | detail   | De foutieve fields waarden zijn: adressering.adresregel1.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -139,7 +139,7 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel2                |
+      | detail   | De foutieve fields waarden zijn: adressering.adresregel2.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -215,7 +215,7 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel3                |
+      | detail   | De foutieve fields waarden zijn: adressering.adresregel3.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -260,7 +260,7 @@ Functionaliteit: autorisatie adressering adresregels PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.land                       |
+      | detail   | De foutieve fields waarden zijn: adressering.land.                      |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 

--- a/features/bevragen/persoon-beperkt/verblijfplaats/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon-beperkt/verblijfplaats/dev/autorisatie-gba.feature
@@ -40,7 +40,7 @@ Functionaliteit: autorisatie verblijfplaatsgegevens PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres            |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -64,7 +64,7 @@ Functionaliteit: autorisatie verblijfplaatsgegevens PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats                         |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.                        |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -121,7 +121,7 @@ Functionaliteit: autorisatie verblijfplaatsgegevens PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres            |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -152,7 +152,7 @@ Functionaliteit: autorisatie verblijfplaatsgegevens PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres            |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 

--- a/features/bevragen/persoon-beperkt/verblijfplaats/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon-beperkt/verblijfplaats/dev/autorisatie-gba.feature
@@ -40,7 +40,6 @@ Functionaliteit: autorisatie verblijfplaatsgegevens PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -64,7 +63,6 @@ Functionaliteit: autorisatie verblijfplaatsgegevens PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.                        |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -121,7 +119,6 @@ Functionaliteit: autorisatie verblijfplaatsgegevens PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -152,7 +149,6 @@ Functionaliteit: autorisatie verblijfplaatsgegevens PersoonBeperkt
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 

--- a/features/bevragen/persoon/adressering/adres-regels/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon/adressering/adres-regels/dev/autorisatie-gba.feature
@@ -54,7 +54,7 @@ Functionaliteit: autorisatie adressering adresregels Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel1                |
+      | detail   | De foutieve fields waarden zijn: adressering.adresregel1.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -130,7 +130,7 @@ Functionaliteit: autorisatie adressering adresregels Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel2                |
+      | detail   | De foutieve fields waarden zijn: adressering.adresregel2.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -203,7 +203,7 @@ Functionaliteit: autorisatie adressering adresregels Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel3                |
+      | detail   | De foutieve fields waarden zijn: adressering.adresregel3.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -246,7 +246,7 @@ Functionaliteit: autorisatie adressering adresregels Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.land                       |
+      | detail   | De foutieve fields waarden zijn: adressering.land.                      |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 

--- a/features/bevragen/persoon/adressering/adres-regels/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon/adressering/adres-regels/dev/autorisatie-gba.feature
@@ -89,7 +89,7 @@ Functionaliteit: autorisatie adressering adresregels Persoon
     Scenario: Afnemer vraagt om adressering.adresregel2 en heeft de daarvoor minimale autorisatie
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
       | Rubrieknummer ad hoc (35.95.60)                       | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10120 90910 81110 81120 81160 81170 81210 81310 81340 | N                        | 20201128                |
+      | 10120 80910 81110 81120 81160 81170 81210 81310 81340 | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
       | naam         | waarde |
       | afnemerID    | 000008 |
@@ -134,19 +134,19 @@ Functionaliteit: autorisatie adressering adresregels Persoon
 
       Voorbeelden:
       | ad hoc rubrieken                                | missende autorisatie            |
-      | 10120 81110 81120 81160 81170 81210 81310 81340 | gemeenteVanInschrijving (90910) |
-      | 10120 90910 81120 81160 81170 81210 81310 81340 | korteStraatnaam (81110)         |
-      | 10120 90910 81110 81160 81170 81210 81310 81340 | huisnummer (81120)              |
-      | 10120 90910 81110 81120 81170 81210 81310 81340 | postcode (81160)                |
-      | 10120 90910 81110 81120 81160 81210 81310 81340 | woonplaats (81170)              |
-      | 10120 90910 81110 81120 81160 81170 81310 81340 | locatiebeschrijving (81210)     |
-      | 10120 90910 81110 81120 81160 81170 81210 81340 | land (81310)                    |
-      | 10120 90910 81110 81120 81160 81170 81210 81310 | regel2 (81340)                  |
+      | 10120 81110 81120 81160 81170 81210 81310 81340 | gemeenteVanInschrijving (80910) |
+      | 10120 80910 81120 81160 81170 81210 81310 81340 | korteStraatnaam (81110)         |
+      | 10120 80910 81110 81160 81170 81210 81310 81340 | huisnummer (81120)              |
+      | 10120 80910 81110 81120 81170 81210 81310 81340 | postcode (81160)                |
+      | 10120 80910 81110 81120 81160 81210 81310 81340 | woonplaats (81170)              |
+      | 10120 80910 81110 81120 81160 81170 81310 81340 | locatiebeschrijving (81210)     |
+      | 10120 80910 81110 81120 81160 81170 81210 81340 | land (81310)                    |
+      | 10120 80910 81110 81120 81160 81170 81210 81310 | regel2 (81340)                  |
 
     Scenario: Afnemer vraagt om adresseringBinnenland.adresregel2 en heeft de daarvoor minimale autorisatie
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
       | Rubrieknummer ad hoc (35.95.60)           | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10120 90910 81110 81120 81160 81170 81210 | N                        | 20201128                |
+      | 10120 80910 81110 81120 81160 81170 81210 | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
       | naam         | waarde |
       | afnemerID    | 000008 |

--- a/features/bevragen/persoon/adressering/adres-regels/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon/adressering/adres-regels/dev/autorisatie-gba.feature
@@ -54,7 +54,6 @@ Functionaliteit: autorisatie adressering adresregels Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel1.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -130,7 +129,6 @@ Functionaliteit: autorisatie adressering adresregels Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel2.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -203,7 +201,6 @@ Functionaliteit: autorisatie adressering adresregels Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.adresregel3.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -246,7 +243,6 @@ Functionaliteit: autorisatie adressering adresregels Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: adressering.land.                      |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 

--- a/features/bevragen/persoon/verblijfplaats/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon/verblijfplaats/dev/autorisatie-gba.feature
@@ -39,7 +39,6 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.<gevraagd veld>.        |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -80,7 +79,6 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.verblijfadres.          |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -117,7 +115,6 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.                        |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -186,7 +183,6 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -237,7 +233,6 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.datumVan.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 

--- a/features/bevragen/persoon/verblijfplaats/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon/verblijfplaats/dev/autorisatie-gba.feature
@@ -39,7 +39,7 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.<gevraagd veld>         |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.<gevraagd veld>.        |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -80,7 +80,7 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.verblijfadres           |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.verblijfadres.          |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -117,7 +117,7 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats                         |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.                        |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -186,7 +186,7 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres            |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.functieAdres.           |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 
@@ -237,7 +237,7 @@ Functionaliteit: autorisatie verblijfplaatsgegevens Persoon
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3             |
       | title    | U bent niet geautoriseerd voor één of meerdere opgegeven field waarden. |
       | status   | 403                                                                     |
-      | detail   | De foutieve fields waarden zijn: verblijfplaats.datumVan                |
+      | detail   | De foutieve fields waarden zijn: verblijfplaats.datumVan.               |
       | code     | authorization                                                           |
       | instance | /haalcentraal/api/brp/personen                                          |
 


### PR DESCRIPTION
Op verzoek van @KayodeBakker  eindigt de detail waarde bij elke autorisatie fout met een punt.

Ook correctie gemeente_code en ontbreken naam|waarde rij boven En stappen

Verwijderen foutdetail n.a.v.#1562