### PR TITLE
leeftijd gebruikt alleen geboortedatum - geen overlijdensdatum

### DIFF
--- a/features/bevragen/autorisatie-gba.feature
+++ b/features/bevragen/autorisatie-gba.feature
@@ -241,8 +241,7 @@ Functionaliteit: autorisatie voor het gebruik van de API
 
       Voorbeelden:
       | fields                                        | ad hoc rubrieken | missende autorisatie                 |
-      | leeftijd                                      | 10120 10310      | overlijdensdatum (60810)             |
-      | leeftijd                                      | 10120 60810      | geboortedatum (10310)                |
+      | leeftijd                                      | 10120            | geboortedatum (10310)                |
       | immigratie.indicatieVestigingVanuitBuitenland | 10120 81410      | datum vestiging in nederland (81420) |
 
     @fout-case


### PR DESCRIPTION
n.a.v. wijzigingen in #1577 correctie autorisatie feature op veld leeftijd: deze vereist autorisatie op geboortedatum (010310), niet op overlijdensdatum (060810), want hiervoor wordt reden opschorting bijhouding gebruikt. Voor opschorting is geen autorisatie vereist, wordt ongevraagd meegeleverd 