### PR TITLE
features verificatie

### DIFF
--- a/features/bevragen/autorisatie-gba.feature
+++ b/features/bevragen/autorisatie-gba.feature
@@ -390,6 +390,48 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | 10120 20120 20240 30310 30320 | meerdere gegevens van ouder 1 en 1 gegeven van ouder 2 |
   
 
+  Rule: Vragen met fields om een veld dat automatisch wordt meegeleverd vereist geen autorisatie voor dat veld
+
+    Abstract Scenario: Afnemer vraagt om <fields> en heeft dat niet in de autorisatie
+      Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
+      | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
+      | 010120                          | N                        | 20201128                |
+      En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
+      | naam         | waarde |
+      | afnemerID    | 000008 |
+      | gemeenteCode | 0800   |
+      En de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | rni-deelnemer (88.10) | omschrijving verdrag (88.20)                |
+      | 0101                  | Belastingverdrag tussen België en Nederland |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | indicatie geheim (70.10) | reden opschorting bijhouding (67.20) |
+      | 7                        | E                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                       |
+      | fields              | <fields>                        |
+      Dan heeft de response een persoon met de volgende gegevens
+      | naam                                     | waarde    |
+      | geheimhoudingPersoonsgegevens            | 7         |
+      | opschortingBijhouding.reden.code         | E         |
+      | opschortingBijhouding.reden.omschrijving | emigratie |
+      En heeft de persoon een 'rni' met de volgende gegevens
+      | naam                   | waarde                                          |
+      | deelnemer.code         | 0101                                            |
+      | deelnemer.omschrijving | Belastingdienst (inzake heffingen en toeslagen) |
+      | omschrijvingVerdrag    | Belastingverdrag tussen België en Nederland     |
+      | categorie              | Persoon                                         |
+
+      Voorbeelden:
+      | fields                        |
+      | geheimhoudingPersoonsgegevens |
+      | opschortingBijhouding.reden   |
+      | naam.inOnderzoek              |
+      | rni                           |
+      | verificatie                   |
+
+
   Rule: Een gemeente als afnemer is geautoriseerd voor alle zoekvragen voor haar eigen inwoners
     Wanneer de afnemer parameter gemeenteVanInschrijving gebruikt 
     en die is gelijk aan de waarde van gemeenteCode in de 'claim', 

--- a/features/bevragen/autorisatie-gba.feature
+++ b/features/bevragen/autorisatie-gba.feature
@@ -400,36 +400,27 @@ Functionaliteit: autorisatie voor het gebruik van de API
       | naam         | waarde |
       | afnemerID    | 000008 |
       | gemeenteCode | 0800   |
-      En de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
-      | rni-deelnemer (88.10) | omschrijving verdrag (88.20)                |
-      | 0101                  | Belastingverdrag tussen België en Nederland |
-      En de persoon heeft de volgende 'inschrijving' gegevens
-      | indicatie geheim (70.10) | reden opschorting bijhouding (67.20) |
-      | 7                        | E                                    |
+      En de persoon met burgerservicenummer '000000024' heeft de volgende 'inschrijving' gegevens
+      | indicatie geheim (70.10) |
+      | 7                        |
       Als gba personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
       | burgerservicenummer | 000000024                       |
-      | fields              | <fields>                        |
+      | fields              | burgerservicenummer,<fields>    |
       Dan heeft de response een persoon met de volgende gegevens
-      | naam                                     | waarde    |
-      | geheimhoudingPersoonsgegevens            | 7         |
-      | opschortingBijhouding.reden.code         | E         |
-      | opschortingBijhouding.reden.omschrijving | emigratie |
-      En heeft de persoon een 'rni' met de volgende gegevens
-      | naam                   | waarde                                          |
-      | deelnemer.code         | 0101                                            |
-      | deelnemer.omschrijving | Belastingdienst (inzake heffingen en toeslagen) |
-      | omschrijvingVerdrag    | Belastingverdrag tussen België en Nederland     |
-      | categorie              | Persoon                                         |
+      | naam                          | waarde    |
+      | burgerservicenummer           | 000000024 |
+      | geheimhoudingPersoonsgegevens | 7         |
 
       Voorbeelden:
-      | fields                        |
-      | geheimhoudingPersoonsgegevens |
-      | opschortingBijhouding.reden   |
-      | naam.inOnderzoek              |
-      | rni                           |
-      | verificatie                   |
+      | fields                          |
+      | geheimhoudingPersoonsgegevens   |
+      | opschortingBijhouding.reden     |
+      | inOnderzoek.burgerservicenummer |
+      | naam.inOnderzoek                |
+      | rni                             |
+      | verificatie                     |
 
 
   Rule: Een gemeente als afnemer is geautoriseerd voor alle zoekvragen voor haar eigen inwoners

--- a/features/bevragen/persoon-beperkt/verificatie/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon-beperkt/verificatie/dev/autorisatie-gba.feature
@@ -35,4 +35,9 @@ Functionaliteit: autorisatie verificatie Persoon Beperkt
       | verificatie                   |
       | verificatie.omschrijving      |
       | verificatie.datum             |
+      | verificatie.datum.type        |
+      | verificatie.datum.datum       |
       | verificatie.datum.langFormaat |
+      | verificatie.datum.jaar        |
+      | verificatie.datum.maand       |
+      | verificatie.datum.onbekend    |

--- a/features/bevragen/persoon-beperkt/verificatie/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon-beperkt/verificatie/dev/autorisatie-gba.feature
@@ -1,0 +1,38 @@
+#language: nl
+
+Functionaliteit: autorisatie verificatie Persoon Beperkt
+
+  Rule: Vragen met fields om verificatie vereist geen autorisatie voor dat veld
+
+    Abstract Scenario: Afnemer vraagt om <fields> en heeft geen verificatie in de autorisatie
+      Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
+      | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
+      | 010120                          | N                        | 20201128                |
+      En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
+      | naam         | waarde |
+      | afnemerID    | 000008 |
+      | gemeenteCode | 0800   |
+      En de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | geboortedatum (03.10) |
+      | Vries                 | 19781103              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                             | waarde               |
+      | datum verificatie (71.10)        | 20020701             |
+      | omschrijving verificatie (71.20) | bewijs nationaliteit |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Vries                               |
+      | geboortedatum | 1978-11-03                          |
+      | fields        | <fields>                            |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam         | waarde               |
+      | datum        | 20020701             |
+      | omschrijving | bewijs nationaliteit |
+
+      Voorbeelden:
+      | fields                        |
+      | verificatie                   |
+      | verificatie.omschrijving      |
+      | verificatie.datum             |
+      | verificatie.datum.langFormaat |

--- a/features/bevragen/persoon-beperkt/verificatie/dev/fields-gba.feature
+++ b/features/bevragen/persoon-beperkt/verificatie/dev/fields-gba.feature
@@ -1,0 +1,44 @@
+#language: nl
+
+Functionaliteit: GbaPersoonBeperkt: verificatie velden vragen met fields
+    Achtergrond:
+      Gegeven de persoon met burgerservicenummer '000000152' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | geboortedatum (03.10) |
+      | Vries                 | 19781103              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                             | waarde               |
+      | datum verificatie (71.10)        | 20020701             |
+      | omschrijving verificatie (71.20) | bewijs nationaliteit |
+
+  Rule: verificatie van de persoonsgegevens wordt bij elke vraag teruggegeven
+
+    Scenario: persoonsgegevens zijn geverifieerd en verificatie wordt niet gevraagd
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Vries                               |
+      | geboortedatum | 1978-11-03                          |
+      | fields        | geslacht                            |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam         | waarde               |
+      | datum        | 20020701             |
+      | omschrijving | bewijs nationaliteit |
+
+    Abstract Scenario: persoonsgegevens zijn geverifieerd en verificatie wordt wel gevraagd
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Vries                               |
+      | geboortedatum | 1978-11-03                          |
+      | fields        | <fields>                            |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam         | waarde               |
+      | datum        | 20020701             |
+      | omschrijving | bewijs nationaliteit |
+
+      Voorbeelden:
+      | fields                        |
+      | verificatie                   |
+      | verificatie.omschrijving      |
+      | verificatie.datum             |
+      | verificatie.datum.langFormaat |

--- a/features/bevragen/persoon-beperkt/verificatie/fields.feature
+++ b/features/bevragen/persoon-beperkt/verificatie/fields.feature
@@ -1,0 +1,77 @@
+#language: nl
+
+Functionaliteit: Persoon: verificatie velden vragen met fields
+    Achtergrond:
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | geboortedatum (03.10) |
+      | Vries                 | 19781103              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                             | waarde               |
+      | datum verificatie (71.10)        | 20020701             |
+      | omschrijving verificatie (71.20) | bewijs nationaliteit |
+
+  Rule: verificatie van de persoonsgegevens wordt bij elke vraag teruggegeven
+
+    Scenario: persoonsgegevens zijn geverifieerd en verificatie wordt niet gevraagd
+      Als personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Vries                               |
+      | geboortedatum | 1978-11-03                          |
+      | fields        | geslacht                            |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam              | waarde               |
+      | datum.type        | Datum                |
+      | datum.datum       | 2002-07-01           |
+      | datum.langFormaat | 1 juli 2002          |
+      | omschrijving      | bewijs nationaliteit |
+
+    Abstract Scenario: persoonsgegevens zijn geverifieerd en verificatie wordt wel gevraagd
+      Als personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Vries                               |
+      | geboortedatum | 1978-11-03                          |
+      | fields        | <fields>                            |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam              | waarde               |
+      | datum.type        | Datum                |
+      | datum.datum       | 2002-07-01           |
+      | datum.langFormaat | 1 juli 2002          |
+      | omschrijving      | bewijs nationaliteit |
+
+      Voorbeelden:
+      | fields                        |
+      | verificatie                   |
+      | verificatie.omschrijving      |
+      | verificatie.datum             |
+      | verificatie.datum.langFormaat |
+
+    Abstract Scenario: 'datum verificatie (71.10)' van het type '<type>'
+      Gegeven de persoon met burgerservicenummer '000000140' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | geboortedatum (03.10) |
+      | Maassen               | 20011027              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                      | waarde     |
+      | datum verificatie (71.10) | <GbaDatum> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Maassen                             |
+      | geboortedatum | 2001-10-27                          |
+      | fields        | verificatie.datum                   |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam              | waarde        |
+      | datum.type        | <type>        |
+      | datum.datum       | <datum>       |
+      | datum.jaar        | <jaar>        |
+      | datum.maand       | <maand>       |
+      | datum.onbekend    | <onbekend>    |
+      | datum.langFormaat | <langFormaat> |
+
+      Voorbeelden:
+      | type           | GbaDatum | datum      | jaar | maand | onbekend | langFormaat  |
+      | Datum          | 20200308 | 2020-03-08 |      |       |          | 8 maart 2020 |
+      | DatumOnbekend  | 00000000 |            |      |       | true     | onbekend     |
+      | JaarDatum      | 20200000 |            | 2020 |       |          | 2020         |
+      | JaarMaandDatum | 20200300 |            | 2020 | 3     |          | maart 2020   |

--- a/features/bevragen/persoon/verificatie/dev/autorisatie-gba.feature
+++ b/features/bevragen/persoon/verificatie/dev/autorisatie-gba.feature
@@ -1,0 +1,34 @@
+#language: nl
+
+Functionaliteit: autorisatie verificatie Persoon
+
+  Rule: Vragen met fields om verificatie vereist geen autorisatie voor dat veld
+
+    Abstract Scenario: Afnemer vraagt om <fields> en heeft geen verificatie in de autorisatie
+      Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
+      | Rubrieknummer ad hoc (35.95.60) | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
+      | 010120                          | N                        | 20201128                |
+      En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
+      | naam         | waarde |
+      | afnemerID    | 000008 |
+      | gemeenteCode | 0800   |
+      En de persoon met burgerservicenummer '000000024' heeft de volgende 'inschrijving' gegevens
+      | naam                             | waarde               |
+      | datum verificatie (71.10)        | 20020701             |
+      | omschrijving verificatie (71.20) | bewijs nationaliteit |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                       |
+      | fields              | <fields>                        |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam         | waarde               |
+      | datum        | 20020701             |
+      | omschrijving | bewijs nationaliteit |
+
+      Voorbeelden:
+      | fields                        |
+      | verificatie                   |
+      | verificatie.omschrijving      |
+      | verificatie.datum             |
+      | verificatie.datum.langFormaat |

--- a/features/bevragen/persoon/verificatie/dev/fields-gba.feature
+++ b/features/bevragen/persoon/verificatie/dev/fields-gba.feature
@@ -1,0 +1,46 @@
+#language: nl
+
+Functionaliteit: GbaPersoon: verificatie velden vragen met fields
+    Achtergrond:
+      Gegeven de persoon met burgerservicenummer '000000152' heeft de volgende 'inschrijving' gegevens
+      | naam                             | waarde               |
+      | datum verificatie (71.10)        | 20020701             |
+      | omschrijving verificatie (71.20) | bewijs nationaliteit |
+
+  Rule: verificatie van de persoonsgegevens wordt bij elke vraag teruggegeven
+
+    Abstract Scenario: persoonsgegevens zijn geverifieerd en verificatie wordt niet gevraagd
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                       |
+      | fields              | <fields>                        |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam         | waarde               |
+      | datum        | 20020701             |
+      | omschrijving | bewijs nationaliteit |
+
+      Voorbeelden:
+      | fields           |
+      | naam.voorvoegsel |
+      | verblijfstitel   |
+      | overlijden.datum |
+      | immigratie       |
+
+    Abstract Scenario: persoonsgegevens zijn geverifieerd en verificatie wordt wel gevraagd
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                       |
+      | fields              | <fields>                        |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam         | waarde               |
+      | datum        | 20020701             |
+      | omschrijving | bewijs nationaliteit |
+
+      Voorbeelden:
+      | fields                        |
+      | verificatie                   |
+      | verificatie.omschrijving      |
+      | verificatie.datum             |
+      | verificatie.datum.langFormaat |

--- a/features/bevragen/persoon/verificatie/fields.feature
+++ b/features/bevragen/persoon/verificatie/fields.feature
@@ -1,0 +1,75 @@
+#language: nl
+
+Functionaliteit: Persoon: verificatie velden vragen met fields
+    Achtergrond:
+      Gegeven de persoon met burgerservicenummer '000000152' heeft de volgende 'inschrijving' gegevens
+      | naam                             | waarde               |
+      | datum verificatie (71.10)        | 20020701             |
+      | omschrijving verificatie (71.20) | bewijs nationaliteit |
+
+  Rule: verificatie van de persoonsgegevens wordt bij elke vraag teruggegeven
+
+    Abstract Scenario: persoonsgegevens zijn geverifieerd en verificatie wordt niet gevraagd
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                       |
+      | fields              | <fields>                        |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam              | waarde               |
+      | datum.type        | Datum                |
+      | datum.datum       | 2002-07-01           |
+      | datum.langFormaat | 1 juli 2002          |
+      | omschrijving      | bewijs nationaliteit |
+
+      Voorbeelden:
+      | fields           |
+      | naam.voorvoegsel |
+      | verblijfstitel   |
+      | overlijden.datum |
+      | immigratie       |
+
+    Abstract Scenario: persoonsgegevens zijn geverifieerd en verificatie wordt wel gevraagd
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                       |
+      | fields              | <fields>                        |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam              | waarde               |
+      | datum.type        | Datum                |
+      | datum.datum       | 2002-07-01           |
+      | datum.langFormaat | 1 juli 2002          |
+      | omschrijving      | bewijs nationaliteit |
+
+      Voorbeelden:
+      | fields                        |
+      | verificatie                   |
+      | verificatie.omschrijving      |
+      | verificatie.datum             |
+      | verificatie.datum.langFormaat |
+
+    Abstract Scenario: 'datum verificatie (71.10)' van het type '<type>'
+      Gegeven de persoon met burgerservicenummer '000000140' heeft de volgende 'inschrijving' gegevens
+      | naam                      | waarde     |
+      | datum verificatie (71.10) | <GbaDatum> |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000140                       |
+      | fields              | verificatie.datum               |
+      Dan heeft de response een persoon met de volgende 'verificatie' gegevens
+      | naam              | waarde        |
+      | datum.type        | <type>        |
+      | datum.datum       | <datum>       |
+      | datum.jaar        | <jaar>        |
+      | datum.maand       | <maand>       |
+      | datum.onbekend    | <onbekend>    |
+      | datum.langFormaat | <langFormaat> |
+
+      Voorbeelden:
+      | type           | GbaDatum | datum      | jaar | maand | onbekend | langFormaat  |
+      | Datum          | 20200308 | 2020-03-08 |      |       |          | 8 maart 2020 |
+      | DatumOnbekend  | 00000000 |            |      |       | true     | onbekend     |
+      | JaarDatum      | 20200000 |            | 2020 |       |          | 2020         |
+      | JaarMaandDatum | 20200300 |            | 2020 | 3     |          | maart 2020   |

--- a/features/step_definitions/step_defs.js
+++ b/features/step_definitions/step_defs.js
@@ -221,6 +221,9 @@ const columnNameMap = new Map([
 
     ['indicatie geheim (70.10)', 'geheim_ind'],
 
+    ['datum verificatie (71.10)', 'verificatie_datum'],
+    ['omschrijving verificatie (71.20)', 'verificatie_oms'],
+
     ['aktenummer (81.20)', 'akte_nr' ],
 	
     ['gemeente document (82.10)', 'doc_gemeente_code' ],


### PR DESCRIPTION
features voor:
- leveren verificatiegegevens
- ongevraagd leveren, ook als niet gevraagd in fields
- negeren verificatie (en andere automatisch geleverde velden) voor autorisatie

N.B. de Dan stappen voor autorisatie moet wellicht worden "Dan heeft de response '1' persoon". Zie https://github.com/BRP-API/Haal-Centraal-BRP-bevragen/pull/1576#discussion_r1091586754
Dat geeft nu nog fout (verwacht dan een lege response), dus is nu nog volledig verwachte response opgenomen als Dan stap.