### PR TITLE
Extra scenario's verblijfstitel gba

### DIFF
--- a/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
+++ b/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
@@ -121,13 +121,14 @@ Achtergrond:
     | datumIngang             | 00000000 |
     | datumEinde              | 00000000 |
 
-    Scenario: vervallen verblijfstitel (aanduiding 98) wordt niet geleverd
-      Gegeven de persoon met burgerservicenummer '000000176' heeft de volgende 'verblijfstitel' gegevens
-      | aanduiding verblijfstitel (39.10) | datum einde verblijfstitel (39.20) | datum ingang verblijfstitel (39.30) |
-      | 98                                | 20660201                           | 20210315                            |
-      Als gba personen wordt gezocht met de volgende parameters
-      | naam                | waarde                          |
-      | type                | RaadpleegMetBurgerservicenummer |
-      | burgerservicenummer | 000000176                       |
-      | fields              | verblijfstitel                  |
-      Dan heeft de response een persoon zonder gegevens
+  Scenario: vervallen verblijfstitel (aanduiding 98) wordt niet geleverd
+    Gegeven de persoon met burgerservicenummer '000000176' heeft de volgende 'verblijfstitel' gegevens
+    | aanduiding verblijfstitel (39.10) | datum einde verblijfstitel (39.20) | datum ingang verblijfstitel (39.30) |
+    | 98                                | 20660201                           | 20210315                            |
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 000000176                       |
+    | fields              | verblijfstitel                  |
+    Dan heeft de response een persoon zonder gegevens
+    

--- a/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
+++ b/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
@@ -36,8 +36,8 @@ Achtergrond:
 
   Scenario: verblijfstitel heeft een datum einde in het verleden
     Gegeven de persoon met burgerservicenummer '000000140' heeft de volgende 'verblijfstitel' gegevens
-    | aanduiding verblijfstitel (39.10) | datum ingang verblijfstitel (39.30) | datum einde verblijfstitel (39.20) |
-    | 37                                | 19980201                            | 20020701                           |
+    | aanduiding verblijfstitel (39.10) | datum ingang verblijfstitel (39.30) | datum einde verblijfstitel (39.20) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) |
+    | 37                                | 19980201                            | 20020701                           | 100000                          | 20230127                       |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
@@ -47,8 +47,8 @@ Achtergrond:
 
   Scenario: verblijfstitel heeft een datum einde vandaag
     Gegeven de persoon met burgerservicenummer '000000140' heeft de volgende 'verblijfstitel' gegevens
-    | aanduiding verblijfstitel (39.10) | datum ingang verblijfstitel (39.30) | datum einde verblijfstitel (39.20) |
-    | 37                                | 19980201                            | vandaag                            |
+    | aanduiding verblijfstitel (39.10) | datum ingang verblijfstitel (39.30) | datum einde verblijfstitel (39.20) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) |
+    | 37                                | 19980201                            | vandaag                            | 100000                          | 20230127                       |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |

--- a/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
+++ b/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
@@ -123,8 +123,8 @@ Achtergrond:
 
   Scenario: vervallen verblijfstitel (aanduiding 98) wordt niet geleverd
     Gegeven de persoon met burgerservicenummer '000000176' heeft de volgende 'verblijfstitel' gegevens
-    | aanduiding verblijfstitel (39.10) | datum einde verblijfstitel (39.20) | datum ingang verblijfstitel (39.30) |
-    | 98                                | 20660201                           | 20210315                            |
+    | aanduiding verblijfstitel (39.10) | datum einde verblijfstitel (39.20) | datum ingang verblijfstitel (39.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) |
+    | 98                                | 20660201                           | 20210315                            | 100000                          | 20230127                       |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |

--- a/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
+++ b/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
@@ -93,3 +93,14 @@ Achtergrond:
     | aanduiding.omschrijving | Onbekend |
     | datumIngang             | 00000000 |
     | datumEinde              | 00000000 |
+
+    Scenario: vervallen verblijfstitel (aanduiding 98) wordt niet geleverd
+      Gegeven de persoon met burgerservicenummer '000000176' heeft de volgende 'verblijfstitel' gegevens
+      | aanduiding verblijfstitel (39.10) | datum einde verblijfstitel (39.20) | datum ingang verblijfstitel (39.30) |
+      | 98                                | 20660201                           | 20210315                            |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000176                       |
+      | fields              | verblijfstitel                  |
+      Dan heeft de response een persoon zonder gegevens

--- a/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
+++ b/features/bevragen/persoon/verblijfstitel/dev/verblijfstitel-gba.feature
@@ -34,7 +34,7 @@ Achtergrond:
     | aanduiding.code         | 37                                                                             |
     | aanduiding.omschrijving | Vw 2000 art. 8, onder e, gemeenschapsonderdaan econ. niet-actief, arbeid spec. |
 
-  Scenario: verblijfstitel heeft een datum einde
+  Scenario: verblijfstitel heeft een datum einde in het verleden
     Gegeven de persoon met burgerservicenummer '000000140' heeft de volgende 'verblijfstitel' gegevens
     | aanduiding verblijfstitel (39.10) | datum ingang verblijfstitel (39.30) | datum einde verblijfstitel (39.20) |
     | 37                                | 19980201                            | 20020701                           |
@@ -42,8 +42,35 @@ Achtergrond:
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 000000140                       |
-    | fields              | verblijfstitel.aanduiding       |
+    | fields              | verblijfstitel                  |
     Dan heeft de response een persoon zonder gegevens
+
+  Scenario: verblijfstitel heeft een datum einde vandaag
+    Gegeven de persoon met burgerservicenummer '000000140' heeft de volgende 'verblijfstitel' gegevens
+    | aanduiding verblijfstitel (39.10) | datum ingang verblijfstitel (39.30) | datum einde verblijfstitel (39.20) |
+    | 37                                | 19980201                            | vandaag                            |
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 000000140                       |
+    | fields              | verblijfstitel                  |
+    Dan heeft de response een persoon zonder gegevens
+
+  Scenario: verblijfstitel heeft een datum einde in de toekomst
+    Gegeven de persoon met burgerservicenummer '000000140' heeft de volgende 'verblijfstitel' gegevens
+    | aanduiding verblijfstitel (39.10) | datum ingang verblijfstitel (39.30) | datum einde verblijfstitel (39.20) |
+    | 37                                | 19980201                            | morgen                             |
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 000000140                       |
+    | fields              | verblijfstitel                  |
+    Dan heeft de response een persoon met de volgende 'verblijfstitel' gegevens
+    | naam                    | waarde                                                                         |
+    | aanduiding.code         | 37                                                                             |
+    | aanduiding.omschrijving | Vw 2000 art. 8, onder e, gemeenschapsonderdaan econ. niet-actief, arbeid spec. |
+    | datumIngang             | 19980201                                                                       |
+    | datumEinde              | morgen                                                                         |
 
   Scenario: persoon's verblijfstitel velden is in onderzoek geweest
     Gegeven de persoon met burgerservicenummer '000000152' heeft de volgende 'verblijfstitel' gegevens


### PR DESCRIPTION
Naar aanleiding van #1585 toevoegen van scenario's aan de verblijfstitel-ga.feature

- scenario voor niet leveren verblijfstitel met aanduiding 98
- scenario's voor expliciet maken leveren wel/niet leveren bij datumEinde: dit is een tot-datum, dus bij datum einde vandaag is verblijfstitel niet meer geldig
- uitbreiden gegevens en fields zodat toont dan niet alleen de aanduiding, maar de hele verblijfstitel dan niet geleverd wordt
