### PR TITLE
Opschorting rni omschrijving

### DIFF
--- a/features/bevragen/persoon-beperkt/opschorting-bijhouding/dev/overzicht-gba.feature
+++ b/features/bevragen/persoon-beperkt/opschorting-bijhouding/dev/overzicht-gba.feature
@@ -156,15 +156,15 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |
 
   Scenario: persoon opgeschort met reden O" (overlijden) wordt gezocht met geslachtsnaam, voornamen en gemeente van inschrijving exclusief overleden personen
     En de persoon heeft de volgende 'inschrijving' gegevens
@@ -216,15 +216,15 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |
 
   Scenario: persoon opgeschort met reden "O" (overlijden) wordt gezocht met nummeraanduiding identificatie exclusief overleden personen
     En de persoon heeft de volgende 'inschrijving' gegevens
@@ -270,15 +270,15 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |
 
   Abstract Scenario: persoon opgeschort met reden "O" (overlijden) wordt gezocht met postcode en huisnummer exclusief overleden personen
     En de persoon heeft de volgende 'inschrijving' gegevens
@@ -327,15 +327,15 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |
 
   Abstract Scenario: persoon opgeschort met reden "O" (overlijden) wordt gezocht met straat, huisnummer en gemeente van inschrijving exclusief overleden personen
     En de persoon heeft de volgende 'inschrijving' gegevens
@@ -387,12 +387,12 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |

--- a/features/bevragen/persoon-beperkt/opschorting-bijhouding/overzicht.feature
+++ b/features/bevragen/persoon-beperkt/opschorting-bijhouding/overzicht.feature
@@ -155,15 +155,15 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |
 
   Scenario: persoon opgeschort met reden O" (overlijden) wordt gezocht met geslachtsnaam, voornamen en gemeente van inschrijving exclusief overleden personen
     En de persoon heeft de volgende 'inschrijving' gegevens
@@ -215,15 +215,15 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |
 
   Scenario: persoon opgeschort met reden "O" (overlijden) wordt gezocht met nummeraanduiding identificatie exclusief overleden personen
     En de persoon heeft de volgende 'inschrijving' gegevens
@@ -269,15 +269,15 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |
 
   Abstract Scenario: persoon opgeschort met reden "O" (overlijden) wordt gezocht met postcode en huisnummer exclusief overleden personen
     En de persoon heeft de volgende 'inschrijving' gegevens
@@ -326,15 +326,15 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |
 
   Abstract Scenario: persoon opgeschort met reden "O" (overlijden) wordt gezocht met straat, huisnummer en gemeente van inschrijving exclusief overleden personen
     En de persoon heeft de volgende 'inschrijving' gegevens
@@ -386,12 +386,12 @@ Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven 
     | opschortingBijhouding.reden.omschrijving | <reden opschorting omschrijving> |
 
     Voorbeelden:
-    | reden opschorting bijhouding | reden opschorting omschrijving       | inclusief overleden personen | zoek overleden personen type |
-    | E                            | emigratie                            | true                         | inclusief                    |
-    | M                            | ministerieel besluit                 | true                         | inclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | true                         | inclusief                    |
-    | .                            | onbekend                             | true                         | inclusief                    |
-    | E                            | emigratie                            | false                        | exclusief                    |
-    | M                            | ministerieel besluit                 | false                        | exclusief                    |
-    | R                            | persoonslijst is aangelegd in de rni | false                        | exclusief                    |
-    | .                            | onbekend                             | false                        | exclusief                    |
+    | reden opschorting bijhouding | reden opschorting omschrijving | inclusief overleden personen | zoek overleden personen type |
+    | E                            | emigratie                      | true                         | inclusief                    |
+    | M                            | ministerieel besluit           | true                         | inclusief                    |
+    | R                            | pl is aangelegd in de rni      | true                         | inclusief                    |
+    | .                            | onbekend                       | true                         | inclusief                    |
+    | E                            | emigratie                      | false                        | exclusief                    |
+    | M                            | ministerieel besluit           | false                        | exclusief                    |
+    | R                            | pl is aangelegd in de rni      | false                        | exclusief                    |
+    | .                            | onbekend                       | false                        | exclusief                    |


### PR DESCRIPTION
Correctie van de omschrijving die bij opschortingBijhouding.reden met code='R' wordt geleverd.

Op sommige plekken stond nog "persoonslijst is aangelegd in de rni". Moet zijn "pl is aangelegd in de rni".

Zie https://github.com/BRP-API/Haal-Centraal-BRP-tabellen-bevragen/blob/master/docs/tabelwaarden.csv.
Dit zijn de waarden zoals die ook in LO BRP staan.

