### PR TITLE
autorisatie foutmelding noemt in detail niet-geautoriseerde parameters op alfabetische volgorde

### DIFF
--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/parameter-autorisatie-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/parameter-autorisatie-gba.feature
@@ -88,7 +88,7 @@ Functionaliteit: autorisatie op parameters bij ZoekMetGeslachtsnaamEnGeboortedat
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                                                   |
       | title    | U bent niet geautoriseerd voor de gebruikte parameter(s).                                                     |
       | status   | 403                                                                                                           |
-      | detail   | U bent niet geautoriseerd voor het gebruik van parameter(s): voornamen, voorvoegsel, gemeenteVanInschrijving. |
+      | detail   | U bent niet geautoriseerd voor het gebruik van parameter(s): gemeenteVanInschrijving, voornamen, voorvoegsel. |
       | code     | unauthorizedParameter                                                                                         |
       | instance | /haalcentraal/api/brp/personen                                                                                |
 

--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/parameter-autorisatie-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/parameter-autorisatie-gba.feature
@@ -83,7 +83,7 @@ Functionaliteit: autorisatie op parameters bij ZoekMetNaamEnGemeenteVanInschrijv
       | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3                         |
       | title    | U bent niet geautoriseerd voor de gebruikte parameter(s).                           |
       | status   | 403                                                                                 |
-      | detail   | U bent niet geautoriseerd voor het gebruik van parameter(s): voorvoegsel, geslacht. |
+      | detail   | U bent niet geautoriseerd voor het gebruik van parameter(s): geslacht, voorvoegsel. |
       | code     | unauthorizedParameter                                                               |
       | instance | /haalcentraal/api/brp/personen                                                      |
 

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/parameter-autorisatie-gba.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/parameter-autorisatie-gba.feature
@@ -108,7 +108,6 @@ Functionaliteit: autorisatie op parameters bij ZoekMetStraatHuisnummerEnGemeente
       | fields                  | burgerservicenummer                              |
       Dan heeft de response 1 persoon
 
-
     Abstract Scenario: Afnemer zoekt met de verplichte parameters en <extra parameter> en heeft uitsluitend de autorisatie die nodig is om deze vraag te mogen stellen
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
       | Rubrieknummer ad hoc (35.95.60)                   | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |


### PR DESCRIPTION
zodat de foutmelding altijd voorspelbaar is, ook wanneer er iets anders wijzigt aan de specificaties of implementatie