### PR TITLE
Niet gespecificeerde parameter moet fout geven

### DIFF
--- a/features/bevragen/raadpleeg-met-burgerservicenummer/dev/fout-cases-gba.feature
+++ b/features/bevragen/raadpleeg-met-burgerservicenummer/dev/fout-cases-gba.feature
@@ -1,0 +1,187 @@
+#language: nl
+
+Functionaliteit: Raadpleeg met burgerservicenummer - fout cases GBA
+
+Rule: De burgerservicenummer parameter is een verplichte parameter
+
+  @fout-case
+  Scenario: De burgerservicenummer parameter is niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam   | waarde                          |
+    | type   | RaadpleegMetBurgerservicenummer |
+    | fields | burgerservicenummer             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: burgerservicenummer.         |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                | reason                  |
+    | required | burgerservicenummer | Parameter is verplicht. |
+
+Rule: De burgerservicenummer parameter bevat een lijst met minimaal één burgerservicenummer
+
+  @fout-case
+  Abstract Scenario: De burgerservicenummer parameter bevat een lege lijst
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer |                                 |
+    | fields              | burgerservicenummer             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: burgerservicenummer.         |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                | reason                          |
+    | minItems | burgerservicenummer | Array bevat minder dan 1 items. |
+
+  @fout-case
+  Scenario: De burgerservicenummer parameter bevat een string van burgerservicenummers gescheiden door een komma
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                             | waarde                          |
+    | type                             | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer (als string) | 999994086,999994086,999994086   |
+    | fields                           | burgerservicenummer             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: burgerservicenummer.         |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code  | name                | reason                   |
+    | array | burgerservicenummer | Parameter is geen array. |
+
+Rule: Een burgerservicenummer is een string bestaande uit exact 9 cijfers
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | <burgerservicenummers>          |
+    | fields              | burgerservicenummer             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: burgerservicenummer[0].      |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                   | reason                                      |
+    | pattern | burgerservicenummer[0] | Waarde voldoet niet aan patroon ^[0-9]{9}$. |
+
+    Voorbeelden:
+    | burgerservicenummers       | titel                                                                       |
+    | 12345678                   | De opgegeven burgerservicenummer is een string met minder dan negen cijfers |
+    | 1234567890                 | De opgegeven burgerservicenummer is een string met meer dan negen cijfers   |
+    | <script>123456789</script> | De opgegeven burgerservicenummer bevat niet-cijfer karakters                |
+
+  @fout-case
+  Scenario: De burgerservicenummer parameter bevat meerdere ongeldige burgerservicenummers
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 1234567890,123456789,1234567890 |
+    | fields              | burgerservicenummer             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                                         |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                    |
+    | title    | Een of meerdere parameters zijn niet correct.                                  |
+    | status   | 400                                                                            |
+    | detail   | De foutieve parameter(s) zijn: burgerservicenummer[0], burgerservicenummer[2]. |
+    | code     | paramsValidation                                                               |
+    | instance | /haalcentraal/api/brp/personen                                                 |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                   | reason                                      |
+    | pattern | burgerservicenummer[0] | Waarde voldoet niet aan patroon ^[0-9]{9}$. |
+    | pattern | burgerservicenummer[2] | Waarde voldoet niet aan patroon ^[0-9]{9}$. |
+
+Rule: De burgerservicenummer parameter bevat een lijst van maximaal 20 burgerservicenummers
+
+  @fout-case
+  Scenario: De burgerservicenummer parameter bevat meer dan 20 burgerservicenummers
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                                                                                                                                                                                            |
+    | type                | RaadpleegMetBurgerservicenummer                                                                                                                                                                                   |
+    | burgerservicenummer | 999999321,999995492,999991802,999995492,999991802,999995492,999991802,999995492,999991802,999995492,999991802,999995492,999991802,999995492,999991802,999995492,999991802,999995492,999991802,999995492,999991802 |
+    | fields              | burgerservicenummer                                                                                                                                                                                               |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: burgerservicenummer.         |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                | reason                         |
+    | maxItems | burgerservicenummer | Array bevat meer dan 20 items. |
+
+Rule: Een gemeenteVanInschrijving waarde bestaat uit 4 cijfers
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                          |
+    | type                    | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer     | 999999321,999995492             |
+    | gemeenteVanInschrijving | <gemeente code>                 |
+    | fields                  | burgerservicenummer             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                    | reason                                      |
+    | pattern | gemeenteVanInschrijving | Waarde voldoet niet aan patroon ^[0-9]{4}$. |
+
+    Voorbeelden:
+    | titel                                                                    | gemeente code                          |
+    | De opgegeven gemeenteVanInschrijving waarde is minder dan 4 cijfers lang | 123                                    |
+    | De opgegeven gemeenteVanInschrijving waarde is meer dan 4 cijfers lang   | 12345                                  |
+    | De opgegeven gemeenteVanInschrijving waarde bevat ongeldige karakters    | <script>alert('hello world');</script> |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                          |
+    | type                    | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer     | 999999321                       |
+    | <parameter>             | <waarde>                        |
+    | fields                  | burgerservicenummer             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter              | waarde     |
+    | zoeken met parameter uit ander zoektype   | voornamen              | Pietje     |
+    | typfout in naam optionele parameter       | gemeenteVanInschijving | 0363       |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet            | een waarde |

--- a/features/bevragen/raadpleeg-met-burgerservicenummer/fout-cases.feature
+++ b/features/bevragen/raadpleeg-met-burgerservicenummer/fout-cases.feature
@@ -157,3 +157,31 @@ Rule: Een gemeenteVanInschrijving waarde bestaat uit 4 cijfers
     | De opgegeven gemeenteVanInschrijving waarde is minder dan 4 cijfers lang | 123                                    |
     | De opgegeven gemeenteVanInschrijving waarde is meer dan 4 cijfers lang   | 12345                                  |
     | De opgegeven gemeenteVanInschrijving waarde bevat ongeldige karakters    | <script>alert('hello world');</script> |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                          |
+    | type                    | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer     | 999999321                       |
+    | <parameter>             | <waarde>                        |
+    | fields                  | burgerservicenummer             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter              | waarde     |
+    | zoeken met parameter uit ander zoektype   | voornamen              | Pietje     |
+    | typfout in naam optionele parameter       | gemeenteVanInschijving | 0363       |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet            | een waarde |

--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/fout-cases-gba.feature
@@ -1,0 +1,503 @@
+#language: nl
+
+Functionaliteit: Zoek met geslachtsnaam en geboortedatum - fout cases GBA
+
+Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
+
+  @fout-case
+  Scenario: De geslachtsnaam en geboortedatum parameters zijn niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam   | waarde                              |
+    | type   | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | fields | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                       |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1  |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.    |
+    | status   | 400                                                          |
+    | detail   | De foutieve parameter(s) zijn: geboortedatum, geslachtsnaam. |
+    | code     | paramsCombination                                            |
+    | instance | /haalcentraal/api/brp/personen                               |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name          | reason                  |
+    | required | geboortedatum | Parameter is verplicht. |
+    | required | geslachtsnaam | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Alleen de geslachtsnaam parameter is niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geboortedatum | 1983-05-26                          |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name          | reason                  |
+    | required | geslachtsnaam | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Alleen de geboortedatum parameter is niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | maassen                             |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geboortedatum.               |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name          | reason                  |
+    | required | geboortedatum | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Een lege string is opgegeven als geslachtsnaam en geboortedatum waarde
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam |                                     |
+    | geboortedatum |                                     |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                       |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1  |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.    |
+    | status   | 400                                                          |
+    | detail   | De foutieve parameter(s) zijn: geboortedatum, geslachtsnaam. |
+    | code     | paramsCombination                                            |
+    | instance | /haalcentraal/api/brp/personen                               |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name          | reason                  |
+    | required | geboortedatum | Parameter is verplicht. |
+    | required | geslachtsnaam | Parameter is verplicht. |
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | <geslachtsnaam>                     |
+    | geboortedatum | <geboortedatum>                     |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <foutieve parameter>.        |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                 | reason                  |
+    | required | <foutieve parameter> | Parameter is verplicht. |
+
+    Voorbeelden:
+    | titel                                                 | geboortedatum | geslachtsnaam | foutieve parameter |
+    | Een lege string is opgegeven als geboortedatum waarde |               | maassen       | geboortedatum      |
+    | Een lege string is opgegeven als geslachtsnaam waarde | 1983-05-26    |               | geslachtsnaam      |
+
+Rule: De geboortedatum is een datum string geformatteerd volgens de [ISO 8601 date format](https://www.w3.org/QA/Tips/iso-date)
+
+  @fout-case
+  Abstract Scenario: Een ongeldig datum is opgegeven als geboortedatum waarde
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | Maassen                             |
+    | geboortedatum | <geboortedatum>                     |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geboortedatum.               |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code | name          | reason                        |
+    | date | geboortedatum | Waarde is geen geldige datum. |
+
+    Voorbeelden:
+    | geboortedatum |
+    | 19830526      |
+    | 26 mei 1983   |
+
+Rule: Een geslachtsnaam is een string bestaande uit minimaal 1 en maximaal 200 karakters. Deze karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | <geslachtsnaam>                     |
+    | geboortedatum | 1983-05-26                          |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name          | reason                                                                                               |
+    | pattern | geslachtsnaam | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+
+    Voorbeelden:
+    | titel                                                     | geslachtsnaam                                                                                                                                                                                                       |
+    | De opgegeven geslachtsnaam is meer dan 200 karakters lang | abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ |
+    | De opgegeven geslachtsnaam bevat ongeldige karakters      | <script>alert('hello world');</script>                                                                                                                                                                              |
+
+Rule: Een geslachtsnaam met wildcard is een string bestaande uit minimaal 3 en maximaal 199 karakters, eindigend met de "*" karakter. De overige karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: De "*" wildcard is opgegeven als eerste karakter in de geslachtsnaam parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | <geslachtsnaam filter>              |
+    | geboortedatum | 1983-05-26                          |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name          | reason                                                                                               |
+    | pattern | geslachtsnaam | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+
+    Voorbeelden:
+    | geslachtsnaam filter |
+    | *sen                 |
+    | *SEN                 |
+
+  @fout-case
+  Abstract Scenario: De "*" wildcard komt meerdere keren voor in de geslachtsnaam parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | <geslachtsnaam filter>              |
+    | geboortedatum | 1983-05-26                          |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name          | reason                                                                                               |
+    | pattern | geslachtsnaam | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+
+    Voorbeelden:
+    | geslachtsnaam filter |
+    | *oen*                |
+    | *OEN*                |
+    | gr**                 |
+    | *r*ot                |
+    | gr*o*                |
+
+  @fout-case
+  Abstract Scenario: De "*" wildcard karakter staat niet aan het eind in de geslachtsnaam parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | <geslachtsnaam filter>              |
+    | geboortedatum | 1983-05-26                          |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name          | reason                                                                                               |
+    | pattern | geslachtsnaam | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+
+    Voorbeelden:
+    | geslachtsnaam filter |
+    | gr*t                 |
+    | g*oot                |
+
+  @fout-case
+  Abstract Scenario: De opgegeven geslachtsnaam exclusief "*" wildcard karakter is niet minimaal 3 karakters lang
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | <geslachtsnaam filter>              |
+    | geboortedatum | 1983-05-26                          |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name          | reason                                                                                               |
+    | pattern | geslachtsnaam | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+
+    Voorbeelden:
+    | geslachtsnaam filter |
+    | *                    |
+    | *n                   |
+    | n*                   |
+    | ab*                  |
+    | ***                  |
+
+  @fout-case
+  Scenario: Er zijn meerdere ongeldige parameters opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                                 |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum    |
+    | geslachtsnaam | <script>alert('hello world');</script> |
+    | geboortedatum | 19830526                               |
+    | fields        | burgerservicenummer                    |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                       |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1  |
+    | title    | Een of meerdere parameters zijn niet correct.                |
+    | status   | 400                                                          |
+    | detail   | De foutieve parameter(s) zijn: geboortedatum, geslachtsnaam. |
+    | code     | paramsValidation                                             |
+    | instance | /haalcentraal/api/brp/personen                               |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name          | reason                                                                                               |
+    | pattern | geslachtsnaam | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+    | date    | geboortedatum | Waarde is geen geldige datum.                                                                        |
+
+Rule: Een voornamen waarde is een string bestaande uit minimaal 1 en maximaal 199 karakters. Deze karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | Jansen                              |
+    | geboortedatum | 1983-05-26                          |
+    | voornamen     | <voornamen>                         |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: voornamen.                   |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name      | reason                                                                 |
+    | pattern | voornamen | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,199}\*{0,1}$. |
+
+    Voorbeelden:
+    | titel                                                   | voornamen                                                                                                                                                                                                           |
+    | De opgegeven voornamen zijn meer dan 200 karakters lang | abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ |
+    | De opgegeven voornamen bevat ongeldige karakters        | <script>alert('hello world');</script>                                                                                                                                                                              |
+
+Rule: Een voornamen waarde met wildcard is een string bestaande uit minimaal 1 en maximaal 199 karakters, eindigend met de "*" karakter. De overige karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: De "*" wildcard is opgegeven als eerste karakter in de voornamen parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | Jansen                              |
+    | geboortedatum | 1983-05-26                          |
+    | voornamen     | <voornamen met wildcard>            |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: voornamen.                   |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name      | reason                                                                 |
+    | pattern | voornamen | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,199}\*{0,1}$. |
+
+    Voorbeelden:
+    | voornamen met wildcard |
+    | *iet                   |
+    | *ETER                  |
+
+Rule: Een voorvoegsel waarde is een string bestaande uit minimaal 1 en maximaal 10 karakters. Deze karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - spatie ( ) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Scenario: Een ongeldige waarde is opgegeven voor de 'voorvoegsel' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                                 |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum    |
+    | geslachtsnaam | maassen                                |
+    | geboortedatum | 1983-05-26                             |
+    | voorvoegsel   | <script>alert('hello world');</script> |
+    | fields        | burgerservicenummer                    |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: voorvoegsel.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name        | reason                                               |
+    | pattern | voorvoegsel | Waarde voldoet niet aan patroon ^[a-zA-Z \']{1,10}$. |
+
+Rule: De geslacht waarde is één karakter lang en kan één van de volgende karakters zijn: M, m, V, v, O, o
+
+  @fout-case
+  Abstract Scenario: Een ongeldige waarde is opgegeven voor de 'geslacht' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | maassen                             |
+    | geboortedatum | 1983-05-26                          |
+    | geslacht      | <geslacht>                          |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslacht.                    |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name     | reason                                                |
+    | pattern | geslacht | Waarde voldoet niet aan patroon ^([Mm]\|[Vv]\|[Oo])$. |
+
+    Voorbeelden:
+    | geslacht                               |
+    | N                                      |
+    | <script>alert('hello world');</script> |
+
+Rule: inclusiefOverledenPersonen is een boolean (true of false waarde)
+
+  @fout-case
+  Abstract Scenario: Een ongeldig waarde is opgegeven voor de 'inclusiefOverledenPersonen' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                       | waarde                              |
+    | type                       | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam              | maassen                             |
+    | geboortedatum              | 1983-05-26                          |
+    | fields                     | burgerservicenummer                 |
+    | inclusiefOverledenPersonen | <inclusief overleden personen>      |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: inclusiefOverledenPersonen.  |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                       | reason                  |
+    | boolean | inclusiefOverledenPersonen | Waarde is geen boolean. |
+
+    Voorbeelden:
+    | inclusief overleden personen |
+    |                              |
+    | geen boolean                 |
+
+Rule: Een gemeenteVanInschrijving waarde bestaat uit 4 cijfers
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                              |
+    | type                    | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam           | maassen                             |
+    | geboortedatum           | 1983-05-26                          |
+    | gemeenteVanInschrijving | <gemeente code>                     |
+    | fields                  | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                    | reason                                      |
+    | pattern | gemeenteVanInschrijving | Waarde voldoet niet aan patroon ^[0-9]{4}$. |
+
+    Voorbeelden:
+    | titel                                                                    | gemeente code                          |
+    | De opgegeven gemeenteVanInschrijving waarde is minder dan 4 cijfers lang | 123                                    |
+    | De opgegeven gemeenteVanInschrijving waarde is meer dan 4 cijfers lang   | 12345                                  |
+    | De opgegeven gemeenteVanInschrijving waarde bevat ongeldige karakters    | <script>alert('hello world');</script> |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | maassen                             |
+    | geboortedatum | 1983-05-26                          |
+    | <parameter>   | <waarde>                            |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter    | waarde     |
+    | zoeken met parameter uit ander zoektype   | postcode     | 1234AB     |
+    | typfout in naam optionele parameter       | voorvoegsels | van der    |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet  | een waarde |

--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/fout-cases.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/fout-cases.feature
@@ -472,3 +472,32 @@ Rule: Een gemeenteVanInschrijving waarde bestaat uit 4 cijfers
     | De opgegeven gemeenteVanInschrijving waarde is minder dan 4 cijfers lang | 123                                    |
     | De opgegeven gemeenteVanInschrijving waarde is meer dan 4 cijfers lang   | 12345                                  |
     | De opgegeven gemeenteVanInschrijving waarde bevat ongeldige karakters    | <script>alert('hello world');</script> |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | maassen                             |
+    | geboortedatum | 1983-05-26                          |
+    | <parameter>   | <waarde>                            |
+    | fields        | burgerservicenummer                 |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter    | waarde     |
+    | zoeken met parameter uit ander zoektype   | postcode     | 1234AB     |
+    | typfout in naam optionele parameter       | voorvoegsels | van der    |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet  | een waarde |

--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/fout-cases-gba.feature
@@ -1,0 +1,408 @@
+#language: nl
+
+Functionaliteit: Zoek met geslachtsnaam, voornamen en gemeente van inschrijving - fout cases GBA
+
+Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parameters
+
+  @fout-case
+  Scenario: De voornamen, geslachtsnaam en gemeenteVanInschrijving parameters zijn niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam   | waarde                               |
+    | type   | ZoekMetNaamEnGemeenteVanInschrijving |
+    | fields | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                                            |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                       |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.                         |
+    | status   | 400                                                                               |
+    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, geslachtsnaam, voornamen. |
+    | code     | paramsCombination                                                                 |
+    | instance | /haalcentraal/api/brp/personen                                                    |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                    | reason                  |
+    | required | gemeenteVanInschrijving | Parameter is verplicht. |
+    | required | geslachtsnaam           | Parameter is verplicht. |
+    | required | voornamen               | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Alleen de geslachtsnaam parameter is niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | Jan                                  |
+    | gemeenteVanInschrijving | 0518                                 |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name          | reason                  |
+    | required | geslachtsnaam | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Alleen de voornamen parameter is niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | geslachtsnaam           | Jansen                               |
+    | gemeenteVanInschrijving | 0518                                 |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: voornamen.                   |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name      | reason                  |
+    | required | voornamen | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Alleen de gemeenteVanInschrijving parameter is niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                               |
+    | type          | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen     | Jan                                  |
+    | geslachtsnaam | Jansen                               |
+    | fields        | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                    | reason                  |
+    | required | gemeenteVanInschrijving | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Een lege string is opgegeven als voornamen, geslachtsnaam en gemeente van inschrijving waarde
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               |                                      |
+    | geslachtsnaam           |                                      |
+    | gemeenteVanInschrijving |                                      |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                                            |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                       |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.                         |
+    | status   | 400                                                                               |
+    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, geslachtsnaam, voornamen. |
+    | code     | paramsCombination                                                                 |
+    | instance | /haalcentraal/api/brp/personen                                                    |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                    | reason                  |
+    | required | gemeenteVanInschrijving | Parameter is verplicht. |
+    | required | geslachtsnaam           | Parameter is verplicht. |
+    | required | voornamen               | Parameter is verplicht. |
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | <voornamen>                          |
+    | geslachtsnaam           | <geslachtsnaam>                      |
+    | gemeenteVanInschrijving | <gemeente van inschrijving>          |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <foutieve parameter>.        |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                 | reason                  |
+    | required | <foutieve parameter> | Parameter is verplicht. |
+
+    Voorbeelden:
+    | titel                                                             | voornamen | geslachtsnaam | gemeente van inschrijving | foutieve parameter      |
+    | Een lege string is opgegeven als voornamen waarde                 |           | Jansen        | 0518                      | voornamen               |
+    | Een lege string is opgegeven als geslachtsnaam waarde             | Jan       |               | 0518                      | geslachtsnaam           |
+    | Een lege string is opgegeven als gemeente van inschrijving waarde | Jan       | Jansen        |                           | gemeenteVanInschrijving |
+
+Rule: Een geslachtsnaam is een string bestaande uit minimaal 1 en maximaal 200 karakters. Deze karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | Jan                                  |
+    | geslachtsnaam           | <geslachtsnaam>                      |
+    | gemeenteVanInschrijving | 0599                                 |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name          | reason                                                                                               |
+    | pattern | geslachtsnaam | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+
+    Voorbeelden:
+    | titel                                                     | geslachtsnaam                                                                                                                                                                                                       |
+    | De opgegeven geslachtsnaam is meer dan 200 karakters lang | abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ |
+    | De opgegeven geslachtsnaam bevat ongeldige karakters      | <script>alert('hello world');</script>                                                                                                                                                                              |
+
+Rule: Een geslachtsnaam met wildcard is een string bestaande uit minimaal 3 en maximaal 199 karakters, eindigend met de "*" karakter. De overige karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: De "*" wildcard karakter staat niet aan het eind in de geslachtsnaam parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | Jan                                  |
+    | geslachtsnaam           | <geslachtsnaam filter>               |
+    | gemeenteVanInschrijving | 0599                                 |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name          | reason                                                                                               |
+    | pattern | geslachtsnaam | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+
+    Voorbeelden:
+    | geslachtsnaam filter |
+    | *sen                 |
+    | *SEN                 |
+    | Jan*sen              |
+
+Rule: Een voornamen waarde is een string bestaande uit minimaal 1 en maximaal 200 karakters. Deze karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | <voornamen>                          |
+    | geslachtsnaam           | Jansen                               |
+    | gemeenteVanInschrijving | 0599                                 |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: voornamen.                   |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name      | reason                                                                                               |
+    | pattern | voornamen | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+
+    Voorbeelden:
+    | titel                                                 | voornamen                                                                                                                                                                                                           |
+    | De opgegeven voornamen is meer dan 199 karakters lang | abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ |
+    | De opgegeven voornamen bevat ongeldige karakters      | <script>alert('hello world');</script>                                                                                                                                                                              |
+
+Rule: Een voornamen waarde met wildcard is een string bestaande uit minimaal 1 en maximaal 199 karakters, eindigend met de "*" karakter. De overige karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: De "*" wildcard is opgegeven als eerste karakter in de voornamen parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | <voornamen>                          |
+    | geslachtsnaam           | Jansen                               |
+    | gemeenteVanInschrijving | 0599                                 |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: voornamen.                   |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name      | reason                                                                                              |
+    | pattern | voornamen | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \.\-\']{1,200}$\|^[a-zA-Z0-9À-ž \.\-\']{3,199}\*{1}$. |
+
+    Voorbeelden:
+    | voornamen met wildcard |
+    | *iet                   |
+    | *ETER                  |
+
+Rule: Een gemeenteVanInschrijving waarde bestaat uit 4 cijfers
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | Jan                                  |
+    | geslachtsnaam           | Jansen                               |
+    | gemeenteVanInschrijving | <gemeente code>                      |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                    | reason                                      |
+    | pattern | gemeenteVanInschrijving | Waarde voldoet niet aan patroon ^[0-9]{4}$. |
+
+    Voorbeelden:
+    | titel                                                                    | gemeente code                          |
+    | De opgegeven gemeenteVanInschrijving waarde is minder dan 4 cijfers lang | 123                                    |
+    | De opgegeven gemeenteVanInschrijving waarde is meer dan 4 cijfers lang   | 12345                                  |
+    | De opgegeven gemeenteVanInschrijving waarde bevat ongeldige karakters    | <script>alert('hello world');</script> |
+
+Rule: Een voorvoegsel waarde is een string bestaande uit minimaal 1 en maximaal 10 karakters. Deze karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - spatie ( ) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Scenario: Een ongeldige waarde is opgegeven voor de 'voorvoegsel' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                                 |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving   |
+    | voornamen               | Jan                                    |
+    | geslachtsnaam           | Jansen                                 |
+    | gemeenteVanInschrijving | 0599                                   |
+    | voorvoegsel             | <script>alert('hello world');</script> |
+    | fields                  | burgerservicenummer                    |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: voorvoegsel.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name        | reason                                               |
+    | pattern | voorvoegsel | Waarde voldoet niet aan patroon ^[a-zA-Z \']{1,10}$. |
+
+Rule: De geslacht waarde is één karakter lang en kan één van de volgende karakters zijn: M, m, V, v, O, o
+
+  @fout-case
+  Abstract Scenario: Een ongeldige waarde is opgegeven voor de 'geslacht' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | Jan                                  |
+    | geslachtsnaam           | Jansen                               |
+    | gemeenteVanInschrijving | 0599                                 |
+    | geslacht                | <geslacht>                           |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: geslacht.                    |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name     | reason                                                |
+    | pattern | geslacht | Waarde voldoet niet aan patroon ^([Mm]\|[Vv]\|[Oo])$. |
+
+    Voorbeelden:
+    | geslacht                               |
+    | N                                      |
+    | <script>alert('hello world');</script> |
+
+Rule: inclusiefOverledenPersonen is een boolean (true of false waarde)
+
+  @fout-case
+  Abstract Scenario: Een ongeldig waarde is opgegeven voor de 'inclusiefOverledenPersonen' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                       | waarde                               |
+    | type                       | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen                  | Jan                                  |
+    | geslachtsnaam              | Jansen                               |
+    | gemeenteVanInschrijving    | 0599                                 |
+    | fields                     | burgerservicenummer                  |
+    | inclusiefOverledenPersonen | <inclusief overleden personen>       |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: inclusiefOverledenPersonen.  |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                       | reason                  |
+    | boolean | inclusiefOverledenPersonen | Waarde is geen boolean. |
+
+    Voorbeelden:
+    | inclusief overleden personen |
+    |                              |
+    | geen boolean                 |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | Jan                                  |
+    | geslachtsnaam           | Jansen                               |
+    | gemeenteVanInschrijving | 0599                                 |
+    | <parameter>             | <waarde>                             |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter    | waarde     |
+    | zoeken met parameter uit ander zoektype   | postcode     | 1234AB     |
+    | typfout in naam optionele parameter       | voorvoegsels | van der    |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet  | een waarde |

--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/fout-cases.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/fout-cases.feature
@@ -376,3 +376,33 @@ Rule: inclusiefOverledenPersonen is een boolean (true of false waarde)
     | inclusief overleden personen |
     |                              |
     | geen boolean                 |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                               |
+    | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+    | voornamen               | Jan                                  |
+    | geslachtsnaam           | Jansen                               |
+    | gemeenteVanInschrijving | 0599                                 |
+    | <parameter>             | <waarde>                             |
+    | fields                  | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter    | waarde     |
+    | zoeken met parameter uit ander zoektype   | postcode     | 1234AB     |
+    | typfout in naam optionele parameter       | voorvoegsels | van der    |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet  | een waarde |

--- a/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/fout-cases-gba.feature
@@ -1,0 +1,124 @@
+#language: nl
+
+Functionaliteit: Zoek met nummeraanduiding identificatie - fout cases GBA
+
+Rule: nummeraanduidingIdentificatie is een verplichte parameter
+
+  @fout-case
+  Scenario: De nummeraanduidingIdentificatie parameter is niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam   | waarde                               |
+    | type   | ZoekMetNummeraanduidingIdentificatie |
+    | fields | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                        |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1   |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.     |
+    | status   | 400                                                           |
+    | detail   | De foutieve parameter(s) zijn: nummeraanduidingIdentificatie. |
+    | code     | paramsCombination                                             |
+    | instance | /haalcentraal/api/brp/personen                                |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                          | reason                  |
+    | required | nummeraanduidingIdentificatie | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Een lege string is opgegeven als nummeraanduiding identificatie waarde
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                          | waarde                               |
+    | type                          | ZoekMetNummeraanduidingIdentificatie |
+    | nummeraanduidingIdentificatie |                                      |
+    | fields                        | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                        |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1   |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.     |
+    | status   | 400                                                           |
+    | detail   | De foutieve parameter(s) zijn: nummeraanduidingIdentificatie. |
+    | code     | paramsCombination                                             |
+    | instance | /haalcentraal/api/brp/personen                                |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                          | reason                  |
+    | required | nummeraanduidingIdentificatie | Parameter is verplicht. |
+
+Rule: Een nummeraanduidingIdentificatie is een string bestaande uit exact 16 cijfers
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                          | waarde                               |
+    | type                          | ZoekMetNummeraanduidingIdentificatie |
+    | nummeraanduidingIdentificatie | <nummeraanduidingIdentificatie>      |
+    | fields                        | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                        |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1   |
+    | title    | Een of meerdere parameters zijn niet correct.                 |
+    | status   | 400                                                           |
+    | detail   | De foutieve parameter(s) zijn: nummeraanduidingIdentificatie. |
+    | code     | paramsValidation                                              |
+    | instance | /haalcentraal/api/brp/personen                                |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                          | reason                                       |
+    | pattern | nummeraanduidingIdentificatie | Waarde voldoet niet aan patroon ^[0-9]{16}$. |
+
+    Voorbeelden:
+    | nummeraanduidingIdentificatie     | titel                                                                              |
+    | 123456789012345                   | De opgegeven nummeraanduidingIdentificatie is een string met minder dan 16 cijfers |
+    | 12345678901234567                 | De opgegeven nummeraanduidingIdentificatie is een string met meer dan 16 cijfers   |
+    | <script>1234567890123456</script> | De opgegeven nummeraanduidingIdentificatie bevat niet-cijfer karakters             |
+
+Rule: inclusiefOverledenPersonen is een boolean (true of false waarde)
+
+  @fout-case
+  Abstract Scenario: Een ongeldig waarde is opgegeven voor de 'inclusiefOverledenPersonen' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                          | waarde                               |
+    | type                          | ZoekMetNummeraanduidingIdentificatie |
+    | nummeraanduidingIdentificatie | 0599200051001501                     |
+    | fields                        | burgerservicenummer                  |
+    | inclusiefOverledenPersonen    | <inclusief overleden personen>       |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: inclusiefOverledenPersonen.  |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                       | reason                  |
+    | boolean | inclusiefOverledenPersonen | Waarde is geen boolean. |
+
+    Voorbeelden:
+    | inclusief overleden personen |
+    |                              |
+    | geen boolean                 |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                          | waarde                               |
+    | type                          | ZoekMetNummeraanduidingIdentificatie |
+    | nummeraanduidingIdentificatie | 0599200051001501                     |
+    | <parameter>                   | <waarde>                             |
+    | fields                        | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter              | waarde     |
+    | zoeken met parameter uit ander zoektype   | voornamen              | Pietje     |
+    | typfout in naam optionele parameter       | gemeenteVanInschijving | 0363       |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet            | een waarde |

--- a/features/bevragen/zoek-met-nummeraanduiding-identificatie/fout-cases.feature
+++ b/features/bevragen/zoek-met-nummeraanduiding-identificatie/fout-cases.feature
@@ -94,3 +94,31 @@ Rule: inclusiefOverledenPersonen is een boolean (true of false waarde)
     | inclusief overleden personen |
     |                              |
     | geen boolean                 |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als personen wordt gezocht met de volgende parameters
+    | naam                          | waarde                               |
+    | type                          | ZoekMetNummeraanduidingIdentificatie |
+    | nummeraanduidingIdentificatie | 0599200051001501                     |
+    | <parameter>                   | <waarde>                             |
+    | fields                        | burgerservicenummer                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter              | waarde     |
+    | zoeken met parameter uit ander zoektype   | voornamen              | Pietje     |
+    | typfout in naam optionele parameter       | gemeenteVanInschijving | 0363       |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet            | een waarde |

--- a/features/bevragen/zoek-met-postcode-en-huisnummer/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/dev/fout-cases-gba.feature
@@ -1,0 +1,301 @@
+#language: nl
+
+Functionaliteit: Zoek met postcode en huisnummer - fout cases GBA
+
+Rule: Postcode en huisnummer zijn verplichte parameters
+
+  @fout-case
+  Scenario: De postcode en huisnummer parameters zijn niet opgegeven 
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam   | waarde                      |
+    | type   | ZoekMetPostcodeEnHuisnummer |
+    | fields | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: postcode, huisnummer.        |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name       | reason                  |
+    | required | postcode   | Parameter is verplicht. |
+    | required | huisnummer | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: De postcode parameter is niet opgegeven 
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam       | waarde                      |
+    | type       | ZoekMetPostcodeEnHuisnummer |
+    | huisnummer | 2                           |
+    | fields     | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: postcode.                    |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name     | reason                  |
+    | required | postcode | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: De huisnummer parameter is niet opgegeven 
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam     | waarde                      |
+    | type     | ZoekMetPostcodeEnHuisnummer |
+    | postcode | 2628HJ                      |
+    | fields   | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: huisnummer.                  |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name       | reason                  |
+    | required | huisnummer | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Een lege string is opgegeven als postcode en huisnummer waarde 
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam       | waarde                      |
+    | type       | ZoekMetPostcodeEnHuisnummer |
+    | postcode   |                             |
+    | huisnummer |                             |
+    | fields     | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: postcode, huisnummer.        |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name       | reason                  |
+    | required | postcode   | Parameter is verplicht. |
+    | required | huisnummer | Parameter is verplicht. |
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam       | waarde                      |
+    | type       | ZoekMetPostcodeEnHuisnummer |
+    | postcode   | <postcode>                  |
+    | huisnummer | <huisnummer>                |
+    | fields     | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <foutieve parameter>.        |
+    | code     | paramsCombination                                           |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                 | reason                  |
+    | required | <foutieve parameter> | Parameter is verplicht. |
+
+    Voorbeelden:
+    | titel                                              | postcode | huisnummer | foutieve parameter |
+    | Een lege string is opgegeven als huisnummer waarde |          | 2          | postcode           |
+    | Een lege waarde is opgegeven als postcode waarde   | 2628HJ   |            | huisnummer         |
+
+Rule: een huisnummer is een getal tussen 1 en 99999
+
+  @fout-case
+  Abstract Scenario: Een ongeldig getal is opgegeven als huisnummer waarde 
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam       | waarde                      |
+    | type       | ZoekMetPostcodeEnHuisnummer |
+    | postcode   | 2628HJ                      |
+    | huisnummer | <huisnummer>                |
+    | fields     | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: huisnummer.                  |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name       | reason                       |
+    | integer | huisnummer | Waarde is geen geldig getal. |
+
+    Voorbeelden:
+    | huisnummer |
+    | twee       |
+    | 0          |
+    | 100000     |
+
+Rule: een postcode is een string bestaande uit 4 cijfers, 0 of 1 spatie en 2 letters (niet hoofdlettergevoelig)
+
+  @fout-case
+  Abstract Scenario: Een ongeldig postcode is opgegeven 
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam       | waarde                      |
+    | type       | ZoekMetPostcodeEnHuisnummer |
+    | postcode   | <postcode>                  |
+    | huisnummer | 2                           |
+    | fields     | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: postcode.                    |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name     | reason                                                             |
+    | pattern | postcode | Waarde voldoet niet aan patroon ^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$. |
+
+    Voorbeelden:
+    | postcode                               |
+    | 0628HJ                                 |
+    | 2628  HJ                               |
+    | <script>alert('hello world');</script> |
+
+  @fout-case
+  Scenario: Meerdere ongeldige parameters zijn opgegeven 
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam       | waarde                      |
+    | type       | ZoekMetPostcodeEnHuisnummer |
+    | postcode   | 0628HJ                      |
+    | huisnummer | twee                        |
+    | fields     | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: postcode, huisnummer.        |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name       | reason                                                             |
+    | pattern | postcode   | Waarde voldoet niet aan patroon ^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$. |
+    | integer | huisnummer | Waarde is geen geldig getal.                                       |
+
+Rule: een huisletter is een string bestaande uit 1 letter (niet hoofdlettergevoelig)
+
+  @fout-case
+  Abstract Scenario: Een ongeldige waarde is opgegeven voor de 'huisletter' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam       | waarde                      |
+    | type       | ZoekMetPostcodeEnHuisnummer |
+    | postcode   | 2628HJ                      |
+    | huisnummer | 2                           |
+    | huisletter | <huisletter>                |
+    | fields     | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: huisletter.                  |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name       | reason                                         |
+    | pattern | huisletter | Waarde voldoet niet aan patroon ^[a-zA-Z]{1}$. |
+
+    Voorbeelden:
+    | huisletter                             |
+    | <script>alert('hello world');</script> |
+    | 1                                      |
+
+Rule: Een huisnummertoevoeging is een string bestaande uit minimaal 1 en maximaal 4 karakters. Deze karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - spatie ( ) en min (-)
+
+  @fout-case
+  Abstract Scenario: Een ongeldige waarde is opgegeven voor de 'huisnummertoevoeging' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                 | waarde                      |
+    | type                 | ZoekMetPostcodeEnHuisnummer |
+    | postcode             | 2628HJ                      |
+    | huisnummer           | 2                           |
+    | huisnummertoevoeging | <huisnummertoevoeging>      |
+    | fields               | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: huisnummertoevoeging.        |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                 | reason                                                 |
+    | pattern | huisnummertoevoeging | Waarde voldoet niet aan patroon ^[a-zA-Z0-9 \-]{1,4}$. |
+
+    Voorbeelden:
+    | huisnummertoevoeging                   |
+    | <script>alert('hello world');</script> |
+    | 123.45                                 |
+
+Rule: inclusiefOverledenPersonen is een boolean (true of false waarde)
+
+  @fout-case
+  Abstract Scenario: Een ongeldig waarde is opgegeven voor de 'inclusiefOverledenPersonen' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                       | waarde                         |
+    | type                       | ZoekMetPostcodeEnHuisnummer    |
+    | postcode                   | 2628HJ                         |
+    | huisnummer                 | 2                              |
+    | fields                     | burgerservicenummer            |
+    | inclusiefOverledenPersonen | <inclusief overleden personen> |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: inclusiefOverledenPersonen.  |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                       | reason                  |
+    | boolean | inclusiefOverledenPersonen | Waarde is geen boolean. |
+
+    Voorbeelden:
+    | inclusief overleden personen |
+    |                              |
+    | geen boolean                 |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam        | waarde                      |
+    | type        | ZoekMetPostcodeEnHuisnummer |
+    | postcode    | 2628HJ                      |
+    | huisnummer  | 2                           |
+    | <parameter> | <waarde>                    |
+    | fields      | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter   | waarde     |
+    | zoeken met parameter uit ander zoektype   | voornamen   | Pietje     |
+    | typfout in naam optionele parameter       | huisleter   | A          |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet | een waarde |

--- a/features/bevragen/zoek-met-postcode-en-huisnummer/fout-cases.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/fout-cases.feature
@@ -270,3 +270,32 @@ Rule: inclusiefOverledenPersonen is een boolean (true of false waarde)
     | inclusief overleden personen |
     |                              |
     | geen boolean                 |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als personen wordt gezocht met de volgende parameters
+    | naam        | waarde                      |
+    | type        | ZoekMetPostcodeEnHuisnummer |
+    | postcode    | 2628HJ                      |
+    | huisnummer  | 2                           |
+    | <parameter> | <waarde>                    |
+    | fields      | burgerservicenummer         |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter   | waarde     |
+    | zoeken met parameter uit ander zoektype   | voornamen   | Pietje     |
+    | typfout in naam optionele parameter       | huisleter   | A          |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet | een waarde |

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/fout-cases-gba.feature
@@ -1,0 +1,264 @@
+#language: nl
+
+Functionaliteit: Zoek met straatnaam/naam openbare ruimte, huisnummer en gemeente van inschrijving - fout cases GBA
+
+Rule: Straat, huisnummer en gemeenteVanInschrijving zijn verplichte parameters
+
+  @fout-case
+  Scenario: De straat, huisnummer en gemeenteVanInschrijving parameters zijn niet opgegeven
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam   | waarde                                           |
+    | type   | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | fields | burgerservicenummer                              |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.                   |
+    | status   | 400                                                                         |
+    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, huisnummer, straat. |
+    | code     | paramsCombination                                                           |
+    | instance | /haalcentraal/api/brp/personen                                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                    | reason                  |
+    | required | straat                  | Parameter is verplicht. |
+    | required | huisnummer              | Parameter is verplicht. |
+    | required | gemeenteVanInschrijving | Parameter is verplicht. |
+
+  @fout-case
+  Scenario: Een lege string is opgegeven als straat, huisnummer en gemeenteVanInschrijving waarde
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                                           |
+    | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | fields                  | burgerservicenummer                              |
+    | straat                  |                                                  |
+    | huisnummer              |                                                  |
+    | gemeenteVanInschrijving |                                                  |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                 |
+    | title    | Minimale combinatie van parameters moet worden opgegeven.                   |
+    | status   | 400                                                                         |
+    | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, huisnummer, straat. |
+    | code     | paramsCombination                                                           |
+    | instance | /haalcentraal/api/brp/personen                                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code     | name                    | reason                  |
+    | required | straat                  | Parameter is verplicht. |
+    | required | huisnummer              | Parameter is verplicht. |
+    | required | gemeenteVanInschrijving | Parameter is verplicht. |
+
+Rule: een straat is een string bestaande uit minimaal 1 en maximaal 80 karakters. Deze karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - cijfers (0-9)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                                           |
+    | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | fields                  | burgerservicenummer                              |
+    | straat                  | <straat>                                         |
+    | huisnummer              | 1                                                |
+    | gemeenteVanInschrijving | 0518                                             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: straat.                      |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name   | reason                                                                                                                                 |
+    | pattern | straat | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \-\'\.]{1,80}$\|^[a-zA-Z0-9À-ž \-\'\.]{7,79}\*{1}$\|^\*{1}[a-zA-Z0-9À-ž \-\'\.]{7,79}$. |
+
+    Voorbeelden:
+    | titel                                             | straat                                                                                                    |
+    | De opgegeven straat is meer dan 80 karakters lang | abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ |
+    | De opgegeven straat bevat ongeldige karakters     | <script>alert('hello world');</script>                                                                    |
+
+Rule: een straat met wildcard is een string bestaande uit minimaal 7 en maximaal 79 karakters, beginnend of eindigend met de "*" karakters. De overige karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - diakrieten (À-ž)
+      - cijfers (0-9)
+      - spatie ( ), punt (.), min (-) en de enkele aanhalingsteken (')
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                                           |
+    | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | straat                  | <straat>                                         |
+    | huisnummer              | 38                                               |
+    | gemeenteVanInschrijving | 0518                                             |
+    | fields                  | burgerservicenummer                              |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: straat.                      |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name   | reason                                                                                                                                 |
+    | pattern | straat | Waarde voldoet niet aan patroon ^[a-zA-Z0-9À-ž \-\'\.]{1,80}$\|^[a-zA-Z0-9À-ž \-\'\.]{7,79}\*{1}$\|^\*{1}[a-zA-Z0-9À-ž \-\'\.]{7,79}$. |
+
+    Voorbeelden:
+    | straat     | titel                                                                                   |
+    | *van Ock*  | De "*" wildcard is opgegeven als eerste en laatste karakter in de straat parameter      |
+    | Laan * van | De "*" wildcard is niet opgegeven als eerste of laatste karakter in de straat parameter |
+    | Laan*      | De straat parameter bevat niet het minimum aantal vereiste karakters                    |
+
+Rule: een huisnummer is een getal tussen 1 en 99999
+
+  @fout-case
+  Abstract Scenario: Een ongeldig getal is opgegeven als huisnummer waarde
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                                           |
+    | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | fields                  | burgerservicenummer                              |
+    | straat                  | leyweg                                           |
+    | huisnummer              | <huisnummer>                                     |
+    | gemeenteVanInschrijving | 0518                                             |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: huisnummer.                  |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name       | reason                       |
+    | integer | huisnummer | Waarde is geen geldig getal. |
+
+    Voorbeelden:
+    | huisnummer |
+    | twee       |
+    | 0          |
+    | 100000     |
+
+Rule: een huisletter is een string bestaande uit 1 letter (niet hoofdlettergevoelig)
+
+  @fout-case
+  Abstract Scenario: Een ongeldige waarde is opgegeven voor de 'huisletter' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                                           |
+    | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | straat                  | leyweg                                           |
+    | huisnummer              | 2                                                |
+    | gemeenteVanInschrijving | 0518                                             |
+    | huisletter              | <huisletter>                                     |
+    | fields                  | burgerservicenummer                              |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: huisletter.                  |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name       | reason                                         |
+    | pattern | huisletter | Waarde voldoet niet aan patroon ^[a-zA-Z]{1}$. |
+
+    Voorbeelden:
+    | huisletter                             |
+    | <script>alert('hello world');</script> |
+    | 1                                      |
+
+Rule: Een huisnummertoevoeging is een string bestaande uit minimaal 1 en maximaal 4 karakters. Deze karakters kunnen zijn:
+      - kleine letters (a-z)
+      - hoofdletters (A-Z)
+      - spatie ( ) en min (-)
+
+  @fout-case
+  Abstract Scenario: Een ongeldige waarde is opgegeven voor de 'huisnummertoevoeging' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                                           |
+    | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | straat                  | leyweg                                           |
+    | huisnummer              | 2                                                |
+    | gemeenteVanInschrijving | 0518                                             |
+    | huisnummertoevoeging    | <huisnummertoevoeging>                           |
+    | fields                  | burgerservicenummer                              |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: huisnummertoevoeging.        |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                 | reason                                                 |
+    | pattern | huisnummertoevoeging | Waarde voldoet niet aan patroon ^[a-zA-Z0-9 \-]{1,4}$. |
+
+    Voorbeelden:
+    | huisnummertoevoeging                   |
+    | <script>alert('hello world');</script> |
+    | 123.45                                 |
+
+Rule: inclusiefOverledenPersonen is een boolean
+
+  @fout-case
+  Abstract Scenario: Een ongeldig waarde is opgegeven voor de 'inclusiefOverledenPersonen' parameter
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                       | waarde                                           |
+    | type                       | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | straat                     | Afrikanerplein                                   |
+    | huisnummer                 | 1                                                |
+    | gemeenteVanInschrijving    | 0363                                             |
+    | fields                     | burgerservicenummer                              |
+    | inclusiefOverledenPersonen | <inclusief overleden personen>                   |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: inclusiefOverledenPersonen.  |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code    | name                       | reason                  |
+    | boolean | inclusiefOverledenPersonen | Waarde is geen boolean. |
+
+    Voorbeelden:
+    | inclusief overleden personen |
+    |                              |
+    | geen boolean                 |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                                           |
+    | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | straat                  | Afrikanerplein                                   |
+    | huisnummer              | 1                                                |
+    | gemeenteVanInschrijving | 0363                                             |
+    | <parameter>             | <waarde>                                         |
+    | fields                  | burgerservicenummer                              |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter   | waarde     |
+    | zoeken met parameter uit ander zoektype   | voornamen   | Pietje     |
+    | typfout in naam optionele parameter       | huisleter   | A          |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet | een waarde |

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/fout-cases.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/fout-cases.feature
@@ -232,3 +232,33 @@ Rule: inclusiefOverledenPersonen is een boolean
     | inclusief overleden personen |
     |                              |
     | geen boolean                 |
+
+Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden gebruikt 
+
+  @fout-case
+  Abstract Scenario: <titel>
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                    | waarde                                           |
+    | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | straat                  | Afrikanerplein                                   |
+    | huisnummer              | 1                                                |
+    | gemeenteVanInschrijving | 0363                                             |
+    | <parameter>             | <waarde>                                         |
+    | fields                  | burgerservicenummer                              |
+    Dan heeft de response een object met de volgende gegevens
+    | naam     | waarde                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
+    | title    | Een of meerdere parameters zijn niet correct.               |
+    | status   | 400                                                         |
+    | detail   | De foutieve parameter(s) zijn: <parameter>.                 |
+    | code     | paramsValidation                                            |
+    | instance | /haalcentraal/api/brp/personen                              |
+    En heeft het object de volgende 'invalidParams' gegevens
+    | code         | name        | reason                      |
+    | unknownParam | <parameter> | Parameter is niet verwacht. |
+
+    Voorbeelden:
+    | titel                                     | parameter   | waarde     |
+    | zoeken met parameter uit ander zoektype   | voornamen   | Pietje     |
+    | typfout in naam optionele parameter       | huisleter   | A          |
+    | zoeken met niet gespecificeerde parameter | bestaatNiet | een waarde |


### PR DESCRIPTION
- foutmelding bij niet-gespecificeerde of onjuiste parameternaam
- features voor parametervalidatie gba