### PR TITLE
correctie gegeven rubrieken autorisatie

### DIFF
--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/parameter-autorisatie-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/parameter-autorisatie-gba.feature
@@ -107,8 +107,8 @@ Functionaliteit: autorisatie op parameters bij ZoekMetNaamEnGemeenteVanInschrijv
 
     Abstract Scenario: Afnemer zoekt met de verplichte parameters en <extra parameter> en heeft uitsluitend de autorisatie die nodig is om deze vraag te mogen stellen
       Gegeven de afnemer met indicatie '000008' heeft de volgende 'autorisatie' gegevens
-      | Rubrieknummer ad hoc (35.95.60)             | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
-      | 10120 10240 10310 <rubriek extra parameter> | N                        | 20201128                |
+      | Rubrieknummer ad hoc (35.95.60)                   | Medium ad hoc (35.95.67) | Datum ingang (35.99.98) |
+      | 10120 10210 10240 <rubriek extra parameter> 80910 | N                        | 20201128                |
       En de geauthenticeerde consumer heeft de volgende 'claim' gegevens
       | naam         | waarde |
       | afnemerID    | 000008 |


### PR DESCRIPTION
n.a.v. #1598:
Niet voldoende rechten

- features\bevragen\zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving\dev\parameter-autorisatie-gba.feature:128
- features\bevragen\zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving\dev\parameter-autorisatie-gba.feature:129