### PR TITLE
Scenario notatie fouten

### DIFF
--- a/features/bevragen/persoon/europees-kiesrecht/dev/fields-gba.feature
+++ b/features/bevragen/persoon/europees-kiesrecht/dev/fields-gba.feature
@@ -7,7 +7,7 @@ Functionaliteit: GBA Persoon: Europees kiesrecht velden vragen met fields
 		Gegeven de persoon met burgerservicenummer '000000164' heeft de volgende gegevens
     | geslachtsnaam (02.40) |
     | Janssen               |
-		Als personen wordt gezocht met de volgende parameters
+		Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 000000164                       |

--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/gba.feature
@@ -30,7 +30,7 @@ Rule: geslacht is niet hoofdlettergevoelig
     Gegeven de persoon met burgerservicenummer '000000027' heeft de volgende gegevens
     | geboortedatum (03.10) | geslachtsnaam (02.40) | geslachtsaanduiding (04.10) |
     | 19830526              | Aedel                 | V                           |
-    Als personen wordt gezocht met de volgende parameters
+    Als gba personen wordt gezocht met de volgende parameters
     | naam          | waarde                              |
     | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
     | geslachtsnaam | Aedel                               |


### PR DESCRIPTION
n.a.v. #1598 de Als stappen aangepast (gba toegevoegd):
Scenario notatie fouten

- features\bevragen\persoon\europees-kiesrecht\dev\fields-gba.feature:6 (Als gba personen)
- features\bevragen\zoek-met-geslachtsnaam-en-geboortedatum\dev\gba.feature:29 (Als gba personen + geslachtsaanduiding dat niet geslacht mag zijn.)