### PR TITLE
correctie fout bij ontbreken required parameter bij request type

### DIFF
--- a/features/bevragen/fields-fout-cases.feature
+++ b/features/bevragen/fields-fout-cases.feature
@@ -13,10 +13,10 @@ Rule: De fields parameter is een verplichte parameter
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: fields.                      |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name   | reason                  |
@@ -32,10 +32,10 @@ Rule: De fields parameter is een verplichte parameter
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: fields.                      |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name   | reason                  |

--- a/features/bevragen/fields-fout-cases.feature
+++ b/features/bevragen/fields-fout-cases.feature
@@ -204,10 +204,10 @@ Rule: De fields parameter bevat verkorte/volledig veld paden die verwijzen naar 
   @fout-case
   Scenario: De fields parameter bevat een veld pad met meer dan 200 valide karakters bij het raadplegen van personen
     Als personen wordt gezocht met de volgende parameters
-    | naam                | waarde                                                                                                                                                                                                   |
-    | type                | RaadpleegMetBurgerservicenummer                                                                                                                                                                          |
-    | burgerservicenummer | 000000139                                                                                                                                                                                                |
-    | fields              | bestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbest |
+    | naam                | waarde                                                                                                                                                                                                    |
+    | type                | RaadpleegMetBurgerservicenummer                                                                                                                                                                           |
+    | burgerservicenummer | 000000139                                                                                                                                                                                                 |
+    | fields              | bestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbestaatooknietbesta |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
@@ -218,7 +218,7 @@ Rule: De fields parameter bevat verkorte/volledig veld paden die verwijzen naar 
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code    | name      | reason                                                   |
-    | pattern | fields[0] | Waarde voldoet niet aan patroon ^[a-zA-Z0-9\._]{1,199}$. |
+    | pattern | fields[0] | Waarde voldoet niet aan patroon ^[a-zA-Z0-9\._]{1,200}$. |
 
   @fout-case
   Scenario: De fields parameter bevat het pad naar een niet bestaand veld (onjuiste case) bij het raadplegen van personen

--- a/features/bevragen/raadpleeg-met-burgerservicenummer/dev/fout-cases-gba.feature
+++ b/features/bevragen/raadpleeg-met-burgerservicenummer/dev/fout-cases-gba.feature
@@ -14,10 +14,10 @@ Rule: De burgerservicenummer parameter is een verplichte parameter
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: burgerservicenummer.         |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                | reason                  |

--- a/features/bevragen/raadpleeg-met-burgerservicenummer/fout-cases.feature
+++ b/features/bevragen/raadpleeg-met-burgerservicenummer/fout-cases.feature
@@ -13,10 +13,10 @@ Rule: De burgerservicenummer parameter is een verplichte parameter
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: burgerservicenummer.         |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                | reason                  |

--- a/features/bevragen/zoek-fout-cases.feature
+++ b/features/bevragen/zoek-fout-cases.feature
@@ -11,10 +11,10 @@ Rule: Er moet een valide zoek type worden opgegeven
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: type.                        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name | reason                  |
@@ -28,10 +28,10 @@ Rule: Er moet een valide zoek type worden opgegeven
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: type.                        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name | reason                  |

--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/fout-cases-gba.feature
@@ -14,10 +14,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                       |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1  |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.    |
+    | title    | Een of meerdere parameters zijn niet correct.                |
     | status   | 400                                                          |
     | detail   | De foutieve parameter(s) zijn: geboortedatum, geslachtsnaam. |
-    | code     | paramsCombination                                            |
+    | code     | paramsValidation                                             |
     | instance | /haalcentraal/api/brp/personen                               |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -34,10 +34,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -53,10 +53,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: geboortedatum.               |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -73,10 +73,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                       |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1  |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.    |
+    | title    | Een of meerdere parameters zijn niet correct.                |
     | status   | 400                                                          |
     | detail   | De foutieve parameter(s) zijn: geboortedatum, geslachtsnaam. |
-    | code     | paramsCombination                                            |
+    | code     | paramsValidation                                             |
     | instance | /haalcentraal/api/brp/personen                               |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -94,10 +94,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: <foutieve parameter>.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                 | reason                  |

--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/fout-cases.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/fout-cases.feature
@@ -13,10 +13,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                       |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1  |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.    |
+    | title    | Een of meerdere parameters zijn niet correct.                |
     | status   | 400                                                          |
     | detail   | De foutieve parameter(s) zijn: geboortedatum, geslachtsnaam. |
-    | code     | paramsCombination                                            |
+    | code     | paramsValidation                                             |
     | instance | /haalcentraal/api/brp/personen                               |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -33,10 +33,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -52,10 +52,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: geboortedatum.               |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -72,10 +72,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                       |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1  |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.    |
+    | title    | Een of meerdere parameters zijn niet correct.                |
     | status   | 400                                                          |
     | detail   | De foutieve parameter(s) zijn: geboortedatum, geslachtsnaam. |
-    | code     | paramsCombination                                            |
+    | code     | paramsValidation                                             |
     | instance | /haalcentraal/api/brp/personen                               |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -93,10 +93,10 @@ Rule: Geslachtsnaam en geboortedatum zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: <foutieve parameter>.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                 | reason                  |

--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/fout-cases-gba.feature
@@ -14,10 +14,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                                            |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                       |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.                         |
+    | title    | Een of meerdere parameters zijn niet correct.                                     |
     | status   | 400                                                                               |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, geslachtsnaam, voornamen. |
-    | code     | paramsCombination                                                                 |
+    | code     | paramsValidation                                                                  |
     | instance | /haalcentraal/api/brp/personen                                                    |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |
@@ -36,10 +36,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -56,10 +56,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: voornamen.                   |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name      | reason                  |
@@ -76,10 +76,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |
@@ -97,10 +97,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                                            |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                       |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.                         |
+    | title    | Een of meerdere parameters zijn niet correct.                                     |
     | status   | 400                                                                               |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, geslachtsnaam, voornamen. |
-    | code     | paramsCombination                                                                 |
+    | code     | paramsValidation                                                                  |
     | instance | /haalcentraal/api/brp/personen                                                    |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |
@@ -120,10 +120,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: <foutieve parameter>.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                 | reason                  |

--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/fout-cases.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/fout-cases.feature
@@ -13,10 +13,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                                            |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                       |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.                         |
+    | title    | Een of meerdere parameters zijn niet correct.                                     |
     | status   | 400                                                                               |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, geslachtsnaam, voornamen. |
-    | code     | paramsCombination                                                                 |
+    | code     | paramsValidation                                                                  |
     | instance | /haalcentraal/api/brp/personen                                                    |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |
@@ -35,10 +35,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: geslachtsnaam.               |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name          | reason                  |
@@ -55,10 +55,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: voornamen.                   |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name      | reason                  |
@@ -75,10 +75,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving.     |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |
@@ -96,10 +96,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                                            |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                       |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.                         |
+    | title    | Een of meerdere parameters zijn niet correct.                                     |
     | status   | 400                                                                               |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, geslachtsnaam, voornamen. |
-    | code     | paramsCombination                                                                 |
+    | code     | paramsValidation                                                                  |
     | instance | /haalcentraal/api/brp/personen                                                    |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |
@@ -119,10 +119,10 @@ Rule: Geslachtsnaam, voornamen en gemeenteVanInschrijving zijn verplichte parame
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: <foutieve parameter>.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                 | reason                  |

--- a/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/fout-cases-gba.feature
@@ -14,10 +14,10 @@ Rule: nummeraanduidingIdentificatie is een verplichte parameter
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                        |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1   |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.     |
+    | title    | Een of meerdere parameters zijn niet correct.                 |
     | status   | 400                                                           |
     | detail   | De foutieve parameter(s) zijn: nummeraanduidingIdentificatie. |
-    | code     | paramsCombination                                             |
+    | code     | paramsValidation                                              |
     | instance | /haalcentraal/api/brp/personen                                |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                          | reason                  |
@@ -33,10 +33,10 @@ Rule: nummeraanduidingIdentificatie is een verplichte parameter
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                        |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1   |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.     |
+    | title    | Een of meerdere parameters zijn niet correct.                 |
     | status   | 400                                                           |
     | detail   | De foutieve parameter(s) zijn: nummeraanduidingIdentificatie. |
-    | code     | paramsCombination                                             |
+    | code     | paramsValidation                                              |
     | instance | /haalcentraal/api/brp/personen                                |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                          | reason                  |

--- a/features/bevragen/zoek-met-nummeraanduiding-identificatie/fout-cases.feature
+++ b/features/bevragen/zoek-met-nummeraanduiding-identificatie/fout-cases.feature
@@ -13,10 +13,10 @@ Rule: nummeraanduidingIdentificatie is een verplichte parameter
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                        |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1   |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.     |
+    | title    | Een of meerdere parameters zijn niet correct.                 |
     | status   | 400                                                           |
     | detail   | De foutieve parameter(s) zijn: nummeraanduidingIdentificatie. |
-    | code     | paramsCombination                                             |
+    | code     | paramsValidation                                              |
     | instance | /haalcentraal/api/brp/personen                                |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                          | reason                  |
@@ -32,10 +32,10 @@ Rule: nummeraanduidingIdentificatie is een verplichte parameter
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                        |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1   |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.     |
+    | title    | Een of meerdere parameters zijn niet correct.                 |
     | status   | 400                                                           |
     | detail   | De foutieve parameter(s) zijn: nummeraanduidingIdentificatie. |
-    | code     | paramsCombination                                             |
+    | code     | paramsValidation                                              |
     | instance | /haalcentraal/api/brp/personen                                |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                          | reason                  |

--- a/features/bevragen/zoek-met-postcode-en-huisnummer/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/dev/fout-cases-gba.feature
@@ -14,10 +14,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: postcode, huisnummer.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name       | reason                  |
@@ -34,10 +34,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: postcode.                    |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name     | reason                  |
@@ -53,10 +53,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: huisnummer.                  |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name       | reason                  |
@@ -73,10 +73,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: postcode, huisnummer.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name       | reason                  |
@@ -94,10 +94,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: <foutieve parameter>.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                 | reason                  |

--- a/features/bevragen/zoek-met-postcode-en-huisnummer/fout-cases.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/fout-cases.feature
@@ -13,10 +13,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: postcode, huisnummer.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name       | reason                  |
@@ -33,10 +33,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: postcode.                    |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name     | reason                  |
@@ -52,10 +52,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: huisnummer.                  |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name       | reason                  |
@@ -72,10 +72,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: postcode, huisnummer.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name       | reason                  |
@@ -93,10 +93,10 @@ Rule: Postcode en huisnummer zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.   |
+    | title    | Een of meerdere parameters zijn niet correct.               |
     | status   | 400                                                         |
     | detail   | De foutieve parameter(s) zijn: <foutieve parameter>.        |
-    | code     | paramsCombination                                           |
+    | code     | paramsValidation                                            |
     | instance | /haalcentraal/api/brp/personen                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                 | reason                  |

--- a/features/bevragen/zoek-met-postcode-en-huisnummer/fout-cases.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/fout-cases.feature
@@ -111,7 +111,7 @@ Rule: een huisnummer is een getal tussen 1 en 99999
 
   @fout-case
   Abstract Scenario: Een ongeldig getal is opgegeven als huisnummer waarde 
-    Als gba personen wordt gezocht met de volgende parameters
+    Als personen wordt gezocht met de volgende parameters
     | naam       | waarde                      |
     | type       | ZoekMetPostcodeEnHuisnummer |
     | postcode   | 2628HJ                      |

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/fout-cases-gba.feature
@@ -14,10 +14,10 @@ Rule: Straat, huisnummer en gemeenteVanInschrijving zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.                   |
+    | title    | Een of meerdere parameters zijn niet correct.                               |
     | status   | 400                                                                         |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, huisnummer, straat. |
-    | code     | paramsCombination                                                           |
+    | code     | paramsValidation                                                            |
     | instance | /haalcentraal/api/brp/personen                                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |
@@ -37,10 +37,10 @@ Rule: Straat, huisnummer en gemeenteVanInschrijving zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.                   |
+    | title    | Een of meerdere parameters zijn niet correct.                               |
     | status   | 400                                                                         |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, huisnummer, straat. |
-    | code     | paramsCombination                                                           |
+    | code     | paramsValidation                                                            |
     | instance | /haalcentraal/api/brp/personen                                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/fout-cases.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/fout-cases.feature
@@ -237,7 +237,7 @@ Rule: Alleen gespecificeerde parameters bij het opgegeven zoektype mogen worden 
 
   @fout-case
   Abstract Scenario: <titel>
-    Als gba personen wordt gezocht met de volgende parameters
+    Als personen wordt gezocht met de volgende parameters
     | naam                    | waarde                                           |
     | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
     | straat                  | Afrikanerplein                                   |

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/fout-cases.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/fout-cases.feature
@@ -13,10 +13,10 @@ Rule: Straat, huisnummer en gemeenteVanInschrijving zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.                   |
+    | title    | Een of meerdere parameters zijn niet correct.                               |
     | status   | 400                                                                         |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, huisnummer, straat. |
-    | code     | paramsCombination                                                           |
+    | code     | paramsValidation                                                            |
     | instance | /haalcentraal/api/brp/personen                                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |
@@ -36,10 +36,10 @@ Rule: Straat, huisnummer en gemeenteVanInschrijving zijn verplichte parameters
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                                      |
     | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1                 |
-    | title    | Minimale combinatie van parameters moet worden opgegeven.                   |
+    | title    | Een of meerdere parameters zijn niet correct.                               |
     | status   | 400                                                                         |
     | detail   | De foutieve parameter(s) zijn: gemeenteVanInschrijving, huisnummer, straat. |
-    | code     | paramsCombination                                                           |
+    | code     | paramsValidation                                                            |
     | instance | /haalcentraal/api/brp/personen                                              |
     En heeft het object de volgende 'invalidParams' gegevens
     | code     | name                    | reason                  |


### PR DESCRIPTION
Bij ontbreken van de een bij het type verwachtte parameters, wordt nu verwacht:
title: Een of meerdere parameters zijn niet correct.
code: paramsValidation