### PR TITLE
Correctie rni feature

### DIFF
--- a/features/bevragen/persoon-beperkt/rni/dev/overzicht-gba.feature
+++ b/features/bevragen/persoon-beperkt/rni/dev/overzicht-gba.feature
@@ -144,7 +144,7 @@ Rule: RNI-deelnemer gegevens die horen bij categorie 01 (Persoon) en/of 08 (Verb
     | geslachtsnaam | Jansen |
     En heeft de persoon de volgende 'verblijfplaats' gegevens
     | naam              | waarde |
-    | land.code         | 5010   |
+    | land.c  ode         | 5010   |
     | land.omschrijving | België |
     En heeft de persoon een 'rni' met de volgende gegevens
     | naam                   | waarde                                          |
@@ -160,12 +160,12 @@ Rule: RNI-deelnemer gegevens die horen bij categorie 01 (Persoon) en/of 08 (Verb
     | categorie              | Verblijfplaats                                    |
 
     Voorbeelden:
-    | fields                                                                                            |
-    | adressering                                                                                       |
-    | naam,adressering.adresregel1                                                                      |
-    | naam.voornamen,naam.geslachtsnaam,adressering.land.omschrijving                                   |
-    | adressering.aanhef,adressering.adresregel2                                                        |
-    | adressering.aanschrijfwijze.naam,adressering.adresregel1,adressering.adresregel2,adressering.land |
+    | fields                                                                |
+    | adressering                                                           |
+    | naam,adressering.adresregel1                                          |
+    | naam.voornamen,naam.geslachtsnaam,adressering.land.omschrijving       |
+    | naam,adressering.adresregel2                                          |
+    | naam,adressering.adresregel1,adressering.adresregel2,adressering.land |
     
   Abstract Scenario: persoon heeft RNI-deelnemer gegevens voor verblijfplaats, maar er worden geen verblijfplaats velden gevraagd
     Gegeven de persoon met burgerservicenummer '000000036' heeft de volgende gegevens

--- a/features/bevragen/persoon-beperkt/rni/dev/overzicht-gba.feature
+++ b/features/bevragen/persoon-beperkt/rni/dev/overzicht-gba.feature
@@ -144,7 +144,7 @@ Rule: RNI-deelnemer gegevens die horen bij categorie 01 (Persoon) en/of 08 (Verb
     | geslachtsnaam | Jansen |
     En heeft de persoon de volgende 'verblijfplaats' gegevens
     | naam              | waarde |
-    | land.c  ode         | 5010   |
+    | land.code         | 5010   |
     | land.omschrijving | België |
     En heeft de persoon een 'rni' met de volgende gegevens
     | naam                   | waarde                                          |

--- a/features/bevragen/persoon/rni/dev/overzicht-gba.feature
+++ b/features/bevragen/persoon/rni/dev/overzicht-gba.feature
@@ -179,18 +179,27 @@ Rule: RNI-deelnemer gegevens die horen bij categorie 01 (Persoon), 04 (Nationali
     | categorie              | Verblijfplaats                                    |
 
     Voorbeelden:
-    | fields                                                  |
-    | gemeenteVanInschrijving                                 |
-    | datumInschrijvingInGemeente                             |
-    | datumInschrijvingInGemeente.type                        |
-    | datumInschrijvingInGemeente.datum                       |
-    | datumInschrijvingInGemeente.langFormaat                 |
-    | immigratie                                              |
-    | immigratie.datumVestigingInNederland                    |
-    | immigratie.datumVestigingInNederland.type               |
-    | immigratie.vanuitVerblijfplaatsOnbekend                 |
-    | immigratie.inOnderzoek                                  |
-    | immigratie.inOnderzoek.datumIngangOnderzoek.langFormaat |
+    | fields                                           |
+    | gemeenteVanInschrijving                          |
+    | gemeenteVanInschrijving.code                     |
+    | gemeenteVanInschrijving.omschrijving             |
+    | datumInschrijvingInGemeente                      |
+    | datumInschrijvingInGemeente.type                 |
+    | datumInschrijvingInGemeente.datum                |
+    | datumInschrijvingInGemeente.langFormaat          |
+    | datumInschrijvingInGemeente.jaar                 |
+    | datumInschrijvingInGemeente.maand                |
+    | datumInschrijvingInGemeente.onbekend             |
+    | immigratie                                       |
+    | immigratie.datumVestigingInNederland             |
+    | immigratie.datumVestigingInNederland.type        |
+    | immigratie.datumVestigingInNederland.datum       |
+    | immigratie.datumVestigingInNederland.langFormaat |
+    | immigratie.indicatieVestigingVanuitBuitenland    |
+    | immigratie.landVanwaarIngeschreven               |
+    | immigratie.landVanwaarIngeschreven.code          |
+    | immigratie.landVanwaarIngeschreven.omschrijving  |
+    | immigratie.vanuitVerblijfplaatsOnbekend          |
 
   Abstract Scenario: persoon heeft RNI-deelnemer gegevens voor meerdere categoriën waarvoor RNI-deelnemer gegevens moet worden geleverd en één of meerdere velden uit al die categoriën wordt gevraagd
     Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens


### PR DESCRIPTION
- verwijderen aanhef en aanschrijfwijze voorbeelden uit persoon-beperkt scenario's
- verwijderen inOnderzoek testgevallen voor RNI - fields inOnderzoek wordt genegeerd
- uitbreiden voorbeelden met sub-velden van datum en waardetabel