### PR TITLE
Correctie aanschrijfwijze

### DIFF
--- a/features/aanschrijfwijze/adellijk.feature
+++ b/features/aanschrijfwijze/adellijk.feature
@@ -232,7 +232,7 @@ Functionaliteit: Als gemeente wil ik de juiste en consistente aanschrijfwijze va
       Voorbeelden:
       | naamgebruik | naam in aanschrijfwijze             |
       | E           | Jonkheer J.A. van den Aedel         |
-      | V           | Jonkheer J.A. de Boer-van den Aedel |
+      | V           | J.A. de Boer-jonkheer van den Aedel |
       | N           | Jonkheer J.A. van den Aedel-de Boer |
 
     Scenario: Jonkheer en naamgebruik "P" voert geen predicaat en geen aanspreekvorm

--- a/features/aanschrijfwijze/dev/meerdere-partners.feature
+++ b/features/aanschrijfwijze/dev/meerdere-partners.feature
@@ -28,3 +28,36 @@ Functionaliteit: Als gemeente wil ik de juiste partnergegevens gebruiken in de a
       Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
       | naam                 | waarde          |
       | aanschrijfwijze.naam | F.C. Groen-Geel |
+
+    Scenario: Persoon met meerdere actuele partners
+      Gegeven de persoon met burgerservicenummer '000000309' heeft de volgende gegevens
+      | naam                           | waarde             |
+      | voornamen (02.10)              | Ferdinand Cornelis |
+      | geslachtsnaam (02.40)          | Groen              |
+      | aanduiding naamgebruik (61.10) | N                  |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                                                               | waarde   |
+      | voorvoegsel (02.30)                                                | de       |
+      | geslachtsnaam (02.40)                                              | Wit      |
+      | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19620104 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                                                               | waarde   |
+      | voorvoegsel (02.30)                                                | in 't    |
+      | geslachtsnaam (02.40)                                              | Roodt    |
+      | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19610831 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                                                               | waarde   |
+      | geslachtsnaam (02.40)                                              | Geel     |
+      | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19581215 |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                                                               | waarde   |
+      | geslachtsnaam (02.40)                                              | Zwart    |
+      | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 19590203 |
+      Als personen wordt gezocht met de volgende parameters
+      | naam                | waarde                           |
+      | type                | RaadpleegMetBurgerservicenummer  |
+      | burgerservicenummer | 000000309                        |
+      | fields              | adressering.aanschrijfwijze.naam |
+      Dan heeft de response een persoon met alleen de volgende 'adressering' gegevens
+      | naam                 | waarde          |
+      | aanschrijfwijze.naam | F.C. Groen-Geel |

--- a/features/bevragen/persoon/adressering/aanhef/adellijke_titel_predicaat.feature
+++ b/features/bevragen/persoon/adressering/aanhef/adellijke_titel_predicaat.feature
@@ -1,3 +1,5 @@
+# language: nl
+
 Functionaliteit: Bij het opstellen van de aanhef maakt een adellijke titel of een predicaat daar onderdeel van uit. 
 
 # Rule: Als de persoon een adellijke titel of predikaat heeft wordt deze gebruikt in het opstellen van de aanhef.

--- a/features/bevragen/persoon/adressering/aanhef/dev/fields-gba.feature
+++ b/features/bevragen/persoon/adressering/aanhef/dev/fields-gba.feature
@@ -60,4 +60,38 @@ Functionaliteit: adressering aanhef veld vragen met fields
       En heeft de 'partner' de volgende 'ontbindingHuwelijkPartnerschap' gegevens
       | naam  | waarde   |
       | datum | 20211109 |
-   
+
+    Scenario: persoon heeft meerdere actuele huwelijken/partnerschappen
+      Gegeven de persoon met burgerservicenummer '000000012' heeft de volgende gegevens
+      | naam                                 | waarde    |
+      | geslachtsnaam (02.40)                | Maassen   |
+      | geslachtsaanduiding (04.10)          | V         |
+      | aanduiding naamgebruik (61.10)       | E         |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | 000000013                   | 20201001                                                           |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | 000000014                   | 20220414                                                           |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000012                       |
+      | fields              | adressering.aanhef              |
+      Dan heeft de response een persoon met de volgende gegevens
+      | naam                  | waarde |
+      | geslacht.code         | V      |
+      | geslacht.omschrijving | vrouw  |
+      En heeft de persoon de volgende 'naam' gegevens
+      | naam                                 | waarde              |
+      | geslachtsnaam                        | Maassen             |
+      | aanduidingNaamgebruik.code           | E                   |
+      | aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
+      Dan heeft de response een persoon met een 'partner' met de volgende gegevens
+      | naam                              | waarde    |
+      | burgerservicenummer               | 000000013 |
+      | aangaanHuwelijkPartnerschap.datum | 20201001  |
+      En heeft de persoon een 'partner' met de volgende gegevens
+      | naam                              | waarde    |
+      | burgerservicenummer               | 000000014 |
+      | aangaanHuwelijkPartnerschap.datum | 20220414  |

--- a/features/bevragen/persoon/adressering/aanhef/partner_met_adellijketitel_predicaat.feature
+++ b/features/bevragen/persoon/adressering/aanhef/partner_met_adellijketitel_predicaat.feature
@@ -1,4 +1,4 @@
-# langage: nl
+# language: nl
 
 Functionaliteit: Bij het opstellen van de aanhef maakt een adellijke titel of een predicaat van de partner onderdeel van uit. 
 

--- a/features/bevragen/persoon/adressering/aanhef/summary.feature
+++ b/features/bevragen/persoon/adressering/aanhef/summary.feature
@@ -41,9 +41,9 @@ Rule: De aanhef van een persoon zonder partner wordt samengesteld door geslacht,
 
     Voorbeelden:
     | voorbeeld | geslacht | aanhef                       |
-    | man       | M        | Geachte heer van Puffelen    |
-    | vrouw     | V        | Geachte mevrouw van Puffelen |
-    | onbekend  | O        | Geachte R.M. van Puffelen    |
+    | man       | M        | Geachte heer Van Puffelen    |
+    | vrouw     | V        | Geachte mevrouw Van Puffelen |
+    | onbekend  | O        | Geachte R.M. Van Puffelen    |
 
   Abstract Scenario: Aanhef voor persoon met voorletters en geslachtsnaam bij geslacht <voorbeeld>
     Gegeven de persoon met burgerservicenummer '000000139' heeft de volgende gegevens

--- a/features/bevragen/persoon/adressering/aanhef/summary.feature
+++ b/features/bevragen/persoon/adressering/aanhef/summary.feature
@@ -18,7 +18,7 @@ Rule: De aanhef van een persoon zonder partner wordt samengesteld door geslacht,
     | M        | Geachte heer           |
     | V        | Geachte mevrouw        |
     | O        | Geachte VL             |
-  - VV: Voorvoegsel geslachtsnaam van de persoon en begint met een hoofdletter
+  - VV: Voorvoegsel geslachtsnaam van de persoon en begint met een hoofdletter, behalve wanneer er voorletters aan voorafgaan (geslacht O)
   - GN: de geslachtsnaam van de persoon 
   - Wanneer een naamcomponent geen of een lege waarde heeft, wordt de overbodige spatie niet opgenomen: niet starten met een spatie, niet eindigen met een spatie, geen dubbele spatie, geen spatie na streepje
 
@@ -43,7 +43,7 @@ Rule: De aanhef van een persoon zonder partner wordt samengesteld door geslacht,
     | voorbeeld | geslacht | aanhef                       |
     | man       | M        | Geachte heer Van Puffelen    |
     | vrouw     | V        | Geachte mevrouw Van Puffelen |
-    | onbekend  | O        | Geachte R.M. Van Puffelen    |
+    | onbekend  | O        | Geachte R.M. van Puffelen    |
 
   Abstract Scenario: Aanhef voor persoon met voorletters en geslachtsnaam bij geslacht <voorbeeld>
     Gegeven de persoon met burgerservicenummer '000000139' heeft de volgende gegevens

--- a/features/bevragen/persoon/adressering/aanschrijfwijze/dev/fields-gba.feature
+++ b/features/bevragen/persoon/adressering/aanschrijfwijze/dev/fields-gba.feature
@@ -97,3 +97,38 @@ Functionaliteit: adressering aanschrijfwijze velden vragen met fields
       En heeft de 'partner' de volgende 'ontbindingHuwelijkPartnerschap' gegevens
       | naam  | waarde   |
       | datum | 20211109 |
+
+    Scenario: persoon heeft meerdere actuele huwelijken/partnerschappen
+      Gegeven de persoon met burgerservicenummer '000000012' heeft de volgende gegevens
+      | naam                                 | waarde    |
+      | geslachtsnaam (02.40)                | Maassen   |
+      | geslachtsaanduiding (04.10)          | V         |
+      | aanduiding naamgebruik (61.10)       | E         |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | 000000013                   | 20201001                                                           |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | 000000014                   | 20220414                                                           |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000012                       |
+      | fields              | adressering.aanschrijfwijze     |
+      Dan heeft de response een persoon met de volgende gegevens
+      | naam                  | waarde |
+      | geslacht.code         | V      |
+      | geslacht.omschrijving | vrouw  |
+      En heeft de persoon de volgende 'naam' gegevens
+      | naam                                 | waarde              |
+      | geslachtsnaam                        | Maassen             |
+      | aanduidingNaamgebruik.code           | E                   |
+      | aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
+      Dan heeft de response een persoon met een 'partner' met de volgende gegevens
+      | naam                              | waarde    |
+      | burgerservicenummer               | 000000013 |
+      | aangaanHuwelijkPartnerschap.datum | 20201001  |
+      En heeft de persoon een 'partner' met de volgende gegevens
+      | naam                              | waarde    |
+      | burgerservicenummer               | 000000014 |
+      | aangaanHuwelijkPartnerschap.datum | 20220414  |

--- a/features/bevragen/persoon/adressering/gebruikinlopendetekst/dev/fields-gba.feature
+++ b/features/bevragen/persoon/adressering/gebruikinlopendetekst/dev/fields-gba.feature
@@ -60,3 +60,38 @@ Functionaliteit: adressering gebruikInLopendeTekst veld vragen met fields
       En heeft de 'partner' de volgende 'ontbindingHuwelijkPartnerschap' gegevens
       | naam  | waarde   |
       | datum | 20211109 |
+
+    Scenario: persoon heeft meerdere actuele huwelijken/partnerschappen
+      Gegeven de persoon met burgerservicenummer '000000012' heeft de volgende gegevens
+      | naam                                 | waarde    |
+      | geslachtsnaam (02.40)                | Maassen   |
+      | geslachtsaanduiding (04.10)          | V         |
+      | aanduiding naamgebruik (61.10)       | E         |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | 000000013                   | 20201001                                                           |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | 000000014                   | 20220414                                                           |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                            |
+      | type                | RaadpleegMetBurgerservicenummer   |
+      | burgerservicenummer | 000000012                         |
+      | fields              | adressering.gebruikInLopendeTekst |
+      Dan heeft de response een persoon met de volgende gegevens
+      | naam                  | waarde |
+      | geslacht.code         | V      |
+      | geslacht.omschrijving | vrouw  |
+      En heeft de persoon de volgende 'naam' gegevens
+      | naam                                 | waarde              |
+      | geslachtsnaam                        | Maassen             |
+      | aanduidingNaamgebruik.code           | E                   |
+      | aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
+      Dan heeft de response een persoon met een 'partner' met de volgende gegevens
+      | naam                              | waarde    |
+      | burgerservicenummer               | 000000013 |
+      | aangaanHuwelijkPartnerschap.datum | 20201001  |
+      En heeft de persoon een 'partner' met de volgende gegevens
+      | naam                              | waarde    |
+      | burgerservicenummer               | 000000014 |
+      | aangaanHuwelijkPartnerschap.datum | 20220414  |


### PR DESCRIPTION
- correctie aanschrijfwijze bij predicaat en naamgebruik V
- extra scenario meerdere partners, waarbij de juiste partner niet gewoon partners[0] is