### PR TITLE
correctie scenario adressering samengestelde namen leveren meerdere partners

### DIFF
--- a/features/bevragen/persoon/adressering/aanhef/dev/fields-gba.feature
+++ b/features/bevragen/persoon/adressering/aanhef/dev/fields-gba.feature
@@ -68,11 +68,11 @@ Functionaliteit: adressering aanhef veld vragen met fields
       | geslachtsaanduiding (04.10)          | V         |
       | aanduiding naamgebruik (61.10)       | E         |
       En de persoon heeft een 'partner' met de volgende gegevens
-      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
-      | 000000013                   | 20201001                                                           |
+      | geslachtsnaam (02.40) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | Groen                 | 20201001                                                           |
       En de persoon heeft een 'partner' met de volgende gegevens
-      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
-      | 000000014                   | 20220414                                                           |
+      | geslachtsnaam (02.40) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | Geel                  | 20220414                                                           |
       Als gba personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -88,10 +88,10 @@ Functionaliteit: adressering aanhef veld vragen met fields
       | aanduidingNaamgebruik.code           | E                   |
       | aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
       Dan heeft de response een persoon met een 'partner' met de volgende gegevens
-      | naam                              | waarde    |
-      | burgerservicenummer               | 000000013 |
-      | aangaanHuwelijkPartnerschap.datum | 20201001  |
+      | naam                              | waarde   |
+      | naam.geslachtsnaam                | Groen    |
+      | aangaanHuwelijkPartnerschap.datum | 20201001 |
       En heeft de persoon een 'partner' met de volgende gegevens
-      | naam                              | waarde    |
-      | burgerservicenummer               | 000000014 |
-      | aangaanHuwelijkPartnerschap.datum | 20220414  |
+      | naam                              | waarde   |
+      | naam.geslachtsnaam                | Geel     |
+      | aangaanHuwelijkPartnerschap.datum | 20220414 |

--- a/features/bevragen/persoon/adressering/aanschrijfwijze/dev/fields-gba.feature
+++ b/features/bevragen/persoon/adressering/aanschrijfwijze/dev/fields-gba.feature
@@ -100,16 +100,16 @@ Functionaliteit: adressering aanschrijfwijze velden vragen met fields
 
     Scenario: persoon heeft meerdere actuele huwelijken/partnerschappen
       Gegeven de persoon met burgerservicenummer '000000012' heeft de volgende gegevens
-      | naam                                 | waarde    |
-      | geslachtsnaam (02.40)                | Maassen   |
-      | geslachtsaanduiding (04.10)          | V         |
-      | aanduiding naamgebruik (61.10)       | E         |
+      | naam                           | waarde  |
+      | geslachtsnaam (02.40)          | Maassen |
+      | geslachtsaanduiding (04.10)    | V       |
+      | aanduiding naamgebruik (61.10) | E       |
       En de persoon heeft een 'partner' met de volgende gegevens
-      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
-      | 000000013                   | 20201001                                                           |
+      | geslachtsnaam (02.40) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | Groen                 | 20201001                                                           |
       En de persoon heeft een 'partner' met de volgende gegevens
-      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
-      | 000000014                   | 20220414                                                           |
+      | geslachtsnaam (02.40) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | Geel                  | 20220414                                                           |
       Als gba personen wordt gezocht met de volgende parameters
       | naam                | waarde                          |
       | type                | RaadpleegMetBurgerservicenummer |
@@ -120,15 +120,15 @@ Functionaliteit: adressering aanschrijfwijze velden vragen met fields
       | geslacht.code         | V      |
       | geslacht.omschrijving | vrouw  |
       En heeft de persoon de volgende 'naam' gegevens
-      | naam                                 | waarde              |
-      | geslachtsnaam                        | Maassen             |
-      | aanduidingNaamgebruik.code           | E                   |
-      | aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
+      | naam                               | waarde              |
+      | geslachtsnaam                      | Maassen             |
+      | aanduidingNaamgebruik.code         | E                   |
+      | aanduidingNaamgebruik.omschrijving | eigen geslachtsnaam |
       Dan heeft de response een persoon met een 'partner' met de volgende gegevens
-      | naam                              | waarde    |
-      | burgerservicenummer               | 000000013 |
-      | aangaanHuwelijkPartnerschap.datum | 20201001  |
+      | naam                              | waarde   |
+      | naam.geslachtsnaam                | Groen    |
+      | aangaanHuwelijkPartnerschap.datum | 20201001 |
       En heeft de persoon een 'partner' met de volgende gegevens
-      | naam                              | waarde    |
-      | burgerservicenummer               | 000000014 |
-      | aangaanHuwelijkPartnerschap.datum | 20220414  |
+      | naam                              | waarde   |
+      | naam.geslachtsnaam                | Geel     |
+      | aangaanHuwelijkPartnerschap.datum | 20220414 |

--- a/features/bevragen/persoon/adressering/gebruikinlopendetekst/dev/fields-gba.feature
+++ b/features/bevragen/persoon/adressering/gebruikinlopendetekst/dev/fields-gba.feature
@@ -68,11 +68,11 @@ Functionaliteit: adressering gebruikInLopendeTekst veld vragen met fields
       | geslachtsaanduiding (04.10)          | V         |
       | aanduiding naamgebruik (61.10)       | E         |
       En de persoon heeft een 'partner' met de volgende gegevens
-      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
-      | 000000013                   | 20201001                                                           |
+      | geslachtsnaam (02.40) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | Groen                 | 20201001                                                           |
       En de persoon heeft een 'partner' met de volgende gegevens
-      | burgerservicenummer (01.20) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
-      | 000000014                   | 20220414                                                           |
+      | geslachtsnaam (02.40) | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) |
+      | Geel                  | 20220414                                                           |
       Als gba personen wordt gezocht met de volgende parameters
       | naam                | waarde                            |
       | type                | RaadpleegMetBurgerservicenummer   |
@@ -88,10 +88,10 @@ Functionaliteit: adressering gebruikInLopendeTekst veld vragen met fields
       | aanduidingNaamgebruik.code           | E                   |
       | aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
       Dan heeft de response een persoon met een 'partner' met de volgende gegevens
-      | naam                              | waarde    |
-      | burgerservicenummer               | 000000013 |
-      | aangaanHuwelijkPartnerschap.datum | 20201001  |
+      | naam                              | waarde   |
+      | naam.geslachtsnaam                | Groen    |
+      | aangaanHuwelijkPartnerschap.datum | 20201001 |
       En heeft de persoon een 'partner' met de volgende gegevens
-      | naam                              | waarde    |
-      | burgerservicenummer               | 000000014 |
-      | aangaanHuwelijkPartnerschap.datum | 20220414  |
+      | naam                              | waarde   |
+      | naam.geslachtsnaam                | Geel     |
+      | aangaanHuwelijkPartnerschap.datum | 20220414 |


### PR DESCRIPTION
Er zat fout in scenario dat bij fields=adressering.aanschrijfwijze (of aanhef of gebruikInLopendeTekst) verwacht werd dat ook burgerservicenummer van de partner geleverd werd. Dat is uiteraard niet correct. 
(was copy-paste fout overgenomen van partner/dev/overzicht-gba.feature)