### PR TITLE
features voor zoeken persoon met geblokkeerde PL

### DIFF
--- a/features/bevragen/raadpleeg-met-burgerservicenummer/dev/geblokkeerde-pl-gba.feature
+++ b/features/bevragen/raadpleeg-met-burgerservicenummer/dev/geblokkeerde-pl-gba.feature
@@ -1,0 +1,18 @@
+#language: nl
+
+Functionaliteit: RaadpleegMetBurgerservicenummer bij geblokkeerde persoonslijst
+
+  Rule: zoeken vindt ook personen waarvan de persoonslijst is geblokkeerd
+  
+    Scenario: Persoonslijst is geblokkeerd
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'inschrijving' gegevens
+      | Datum ingang blokkering (66.20) |
+      | 20230221                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                       |
+      | fields              | burgerservicenummer             |
+      Dan heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000024 |

--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/geblokkeerde-pl-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/geblokkeerde-pl-gba.feature
@@ -1,0 +1,29 @@
+#language: nl
+
+Functionaliteit: ZoekMetGeslachtsnaamEnGeboortedatum bij geblokkeerde persoonslijst
+
+  Rule: zoeken vindt ook personen waarvan de persoonslijst is geblokkeerd
+
+    Scenario: Persoonslijst is geblokkeerd
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000048' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Jan Peter         |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | Datum ingang blokkering (66.20) |
+      | 20230221                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Maassen                             |
+      | geboortedatum | 1983-05-26                          |
+      | fields        | burgerservicenummer                 |
+      Dan heeft de response 2 personen
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000024 |
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000048 |

--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/geblokkeerde-pl-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/geblokkeerde-pl-gba.feature
@@ -1,0 +1,36 @@
+  #language: nl
+
+  Functionaliteit: ZoekMetNaamEnGemeenteVanInschrijving bij geblokkeerde persoonslijst
+
+    Rule: zoeken vindt ook personen waarvan de persoonslijst is geblokkeerd
+
+      Scenario: Persoonslijst is geblokkeerd
+        Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+        | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+        | 19830526              | Maassen               | Jan Peter         |
+        En de persoon heeft de volgende 'verblijfplaats' gegevens
+        | gemeente van inschrijving (09.10) |
+        | 0014                              |
+        En de persoon met burgerservicenummer '000000048' heeft de volgende gegevens
+        | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+        | 19830526              | Maassen               | Jan Peter         |
+        En de persoon heeft de volgende 'inschrijving' gegevens
+        | Datum ingang blokkering (66.20) |
+        | 20230221                        |
+        En de persoon heeft de volgende 'verblijfplaats' gegevens
+        | gemeente van inschrijving (09.10) |
+        | 0014                              |
+        Als gba personen wordt gezocht met de volgende parameters
+        | naam                    | waarde                               |
+        | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+        | geslachtsnaam           | Maassen                              |
+        | voornamen               | Jan Peter                            |
+        | gemeenteVanInschrijving | 0014                                 |
+        | fields                  | burgerservicenummer                  |
+        Dan heeft de response 2 personen
+        En heeft de response een persoon met de volgende gegevens
+        | naam                | waarde    |
+        | burgerservicenummer | 000000024 |
+        En heeft de response een persoon met de volgende gegevens
+        | naam                | waarde    |
+        | burgerservicenummer | 000000048 |

--- a/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/geblokkeerde-pl-gba.feature
+++ b/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/geblokkeerde-pl-gba.feature
@@ -1,0 +1,31 @@
+#language: nl
+
+Functionaliteit: ZoekMetNummeraanduidingIdentificatie bij geblokkeerde persoonslijst
+
+  Rule: zoeken vindt ook personen waarvan de persoonslijst is geblokkeerd
+
+    Scenario: Persoonslijst is geblokkeerd
+      Gegeven een adres heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0518                 | 0518200000617227                           |
+      En de persoon met burgerservicenummer '000000024' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0518                              |
+      En de persoon met burgerservicenummer '000000048' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0518                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | Datum ingang blokkering (66.20) |
+      | 20230221                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                          | waarde                               |
+      | type                          | ZoekMetNummeraanduidingIdentificatie |
+      | nummeraanduidingIdentificatie | 0518200000617227                     |
+      | fields                        | burgerservicenummer                  |
+      Dan heeft de response 2 personen
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000024 |
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000048 |

--- a/features/bevragen/zoek-met-postcode-en-huisnummer/dev/geblokkeerde-pl-gba.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/dev/geblokkeerde-pl-gba.feature
@@ -1,0 +1,35 @@
+#language: nl
+
+Functionaliteit: ZoekMetPostcodeEnHuisnummer bij geblokkeerde persoonslijst
+
+  Rule: zoeken vindt ook personen waarvan de persoonslijst is geblokkeerd
+
+    Scenario: Persoonslijst is geblokkeerd
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | postcode (11.60) | huisnummer (11.20) | huisletter (11.30) |
+      | 0599                 | 2628HJ           | 2                  | A                  |
+      En de persoon met burgerservicenummer '000000048' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | postcode (11.60) | huisnummer (11.20) | huisletter (11.30) |
+      | 0599                 | 2628HJ           | 2                  | B                  |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | Datum ingang blokkering (66.20) |
+      | 20230221                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam       | waarde                      |
+      | type       | ZoekMetPostcodeEnHuisnummer |
+      | postcode   | 2628HJ                      |
+      | huisnummer | 2                           |
+      | fields     | burgerservicenummer         |
+      Dan heeft de response 2 personen
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000024 |
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000048 |

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/geblokkeerde-pl-gba.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/geblokkeerde-pl-gba.feature
@@ -1,0 +1,36 @@
+#language: nl
+
+Functionaliteit: ZoekMetStraatHuisnummerEnGemeenteVanInschrijving bij geblokkeerde persoonslijst
+
+  Rule: zoeken vindt ook personen waarvan de persoonslijst is geblokkeerd
+
+    Scenario: Persoonslijst is geblokkeerd
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) | huisletter (11.30) |
+      | 0599                 | Boterdiep          | 2                  | A                  |
+      En de persoon met burgerservicenummer '000000048' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) | huisletter (11.30) |
+      | 0599                 | Boterdiep          | 2                  | B                  |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | Datum ingang blokkering (66.20) |
+      | 20230221                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                                           |
+      | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+      | straat                  | Boterdiep                                        |
+      | huisnummer              | 2                                                |
+      | gemeenteVanInschrijving | 0599                                             |
+      | fields                  | burgerservicenummer                              |
+      Dan heeft de response 2 personen
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000024 |
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000048 |

--- a/features/step_definitions/step_defs.js
+++ b/features/step_definitions/step_defs.js
@@ -214,6 +214,8 @@ const columnNameMap = new Map([
     ['bijzonder nederlanderschap (65.10)', 'bijzonder_nl_aand'],
     ['bijzonder Nederlanderschap (65.10)', 'bijzonder_nl_aand' ],
 
+    ['Datum ingang blokkering (66.20)', 'pl_blokkering_start_datum'],
+
     ['datum opschorting bijhouding (67.10)', 'bijhouding_opschort_datum' ],
     ['reden opschorting bijhouding (67.20)', 'bijhouding_opschort_reden'],
 


### PR DESCRIPTION
In de huidige gba API implementatie worden geblokkeerde persoonslijsten om de een of andere reden niet geleverd. daarom features/scenario's toegevoegd die tonen dat deze wel geleverd moeten worden