### PR TITLE
Maximaal aantal zoekresultaten

### DIFF
--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -55,7 +55,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetGeslachtsnaamEnGeboorteda
 
     @fout-case
     Scenario: Meer dan 10 personen gevonden
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam          | waarde                              |
       | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
       | geslachtsnaam | Maassen                             |
@@ -71,7 +71,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetGeslachtsnaamEnGeboorteda
       | instance | /haalcentraal/api/brp/personen                                            |
 
     Scenario: Verfijnde zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam          | waarde                              |
       | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
       | geslachtsnaam | Maassen                             |
@@ -82,7 +82,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetGeslachtsnaamEnGeboorteda
 
     @fout-case
     Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                       | waarde                              |
       | type                       | ZoekMetGeslachtsnaamEnGeboortedatum |
       | geslachtsnaam              | Maassen                             |

--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -1,0 +1,100 @@
+#language: nl
+
+@gba
+Functionaliteit: maximaal aantal zoekresultaten ZoekMetGeslachtsnaamEnGeboortedatum
+
+  Achtergrond:
+      Gegeven de persoon met burgerservicenummer '000000001' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000002' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000003' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000004' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000005' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000006' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000007' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000008' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000009' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000010' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon met burgerservicenummer '000000011' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | O      |
+      En de persoon met burgerservicenummer '000000012' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | F      |
+      En de persoon met burgerservicenummer '000000013' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) | voornamen (02.10) |
+      | 19830526              | Maassen               | Jan Peter         |
+    
+
+  Rule: Wanneer er meer dan 10 personen gevonden worden bij zoeken wordt een foutmelding gegeven
+
+    @fout-case
+    Scenario: Meer dan 10 personen gevonden
+      Als personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Maassen                             |
+      | geboortedatum | 1983-05-26                          |
+      | fields        | burgerservicenummer                 |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |
+
+    Scenario: Verfijnde zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
+      Als personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Maassen                             |
+      | geboortedatum | 1983-05-26                          |
+      | voornamen     | Pieter                              |
+      | fields        | burgerservicenummer                 |
+      Dan heeft de response 10 personen
+
+    @fout-case
+    Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
+      Als personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                              |
+      | type                       | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam              | Maassen                             |
+      | geboortedatum              | 1983-05-26                          |
+      | voornamen                  | Pieter                              |
+      | inclusiefOverledenPersonen | true                                |
+      | fields                     | burgerservicenummer                 |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |

--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -1,0 +1,142 @@
+#language: nl
+
+@gba
+Functionaliteit: maximaal aantal zoekresultaten ZoekMetNaamEnGemeenteVanInschrijving
+
+  Achtergrond:
+      Gegeven de persoon met burgerservicenummer '000000001' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000002' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000003' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000004' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000005' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000006' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000007' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000008' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000009' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000010' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon met burgerservicenummer '000000011' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | O      |
+      En de persoon met burgerservicenummer '000000012' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | M                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | F      |
+      En de persoon met burgerservicenummer '000000013' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | geslachtsaanduiding (04.10) |
+      | Maassen               | Pieter            | V                           |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+    
+
+  Rule: Wanneer er meer dan 10 personen gevonden worden bij zoeken wordt een foutmelding gegeven
+
+    @fout-case
+    Scenario: Meer dan 10 personen gevonden
+      Als personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                               |
+      | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+      | geslachtsnaam           | Maassen                              |
+      | voornamen               | Pieter                               |
+      | gemeenteVanInschrijving | 0014                                 |
+      | fields                  | burgerservicenummer                  |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |
+
+    Scenario: Verfijnde zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
+      Als personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                               |
+      | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+      | geslachtsnaam           | Maassen                              |
+      | voornamen               | Pieter                               |
+      | gemeenteVanInschrijving | 0014                                 |
+      | geslacht                | M                                    |
+      | fields                  | burgerservicenummer                  |
+      Dan heeft de response 10 personen
+
+    @fout-case
+    Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
+      Als personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                               |
+      | type                       | ZoekMetNaamEnGemeenteVanInschrijving |
+      | geslachtsnaam              | Maassen                              |
+      | voornamen                  | Pieter                               |
+      | gemeenteVanInschrijving    | 0014                                 |
+      | geslacht                   | M                                    |
+      | inclusiefOverledenPersonen | true                                 |
+      | fields                     | burgerservicenummer                  |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |

--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -94,7 +94,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetNaamEnGemeenteVanInschrij
 
     @fout-case
     Scenario: Meer dan 10 personen gevonden
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                    | waarde                               |
       | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
       | geslachtsnaam           | Maassen                              |
@@ -111,7 +111,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetNaamEnGemeenteVanInschrij
       | instance | /haalcentraal/api/brp/personen                                            |
 
     Scenario: Verfijnde zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                    | waarde                               |
       | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
       | geslachtsnaam           | Maassen                              |
@@ -123,7 +123,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetNaamEnGemeenteVanInschrij
 
     @fout-case
     Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                       | waarde                               |
       | type                       | ZoekMetNaamEnGemeenteVanInschrijving |
       | geslachtsnaam              | Maassen                              |

--- a/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -91,7 +91,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetNummeraanduidingIdentific
 
     @fout-case
     Scenario: Meer dan 10 personen gevonden
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                          | waarde                               |
       | type                          | ZoekMetNummeraanduidingIdentificatie |
       | nummeraanduidingIdentificatie | 0518200000617228                     |
@@ -106,7 +106,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetNummeraanduidingIdentific
       | instance | /haalcentraal/api/brp/personen                                            |
 
     Scenario: Zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                          | waarde                               |
       | type                          | ZoekMetNummeraanduidingIdentificatie |
       | nummeraanduidingIdentificatie | 0518200000617227                     |
@@ -115,7 +115,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetNummeraanduidingIdentific
 
     @fout-case
     Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                          | waarde                               |
       | type                          | ZoekMetNummeraanduidingIdentificatie |
       | nummeraanduidingIdentificatie | 0518200000617227                     |

--- a/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -1,0 +1,131 @@
+#language: nl
+
+@gba
+Functionaliteit: maximaal aantal zoekresultaten ZoekMetNummeraanduidingIdentificatie
+
+  Achtergrond:
+      Gegeven een adres heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0599                 | 0518200000617227                           |
+      En de persoon met burgerservicenummer '000000001' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000002' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000003' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000004' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000005' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000006' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000007' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000008' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000009' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000010' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000011' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | O      |
+      En de persoon met burgerservicenummer '000000012' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | F      |
+      En een adres heeft de volgende gegevens
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0599                 | 0518200000617228                           |
+      En de persoon met burgerservicenummer '000000021' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000022' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000023' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000024' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000025' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000026' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000027' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000028' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000029' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000030' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000031' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+    
+
+  Rule: Wanneer er meer dan 10 personen gevonden worden bij zoeken wordt een foutmelding gegeven
+
+    @fout-case
+    Scenario: Meer dan 10 personen gevonden
+      Als personen wordt gezocht met de volgende parameters
+      | naam                          | waarde                               |
+      | type                          | ZoekMetNummeraanduidingIdentificatie |
+      | nummeraanduidingIdentificatie | 0518200000617228                     |
+      | fields                        | burgerservicenummer                  |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |
+
+    Scenario: Zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
+      Als personen wordt gezocht met de volgende parameters
+      | naam                          | waarde                               |
+      | type                          | ZoekMetNummeraanduidingIdentificatie |
+      | nummeraanduidingIdentificatie | 0518200000617227                     |
+      | fields                        | burgerservicenummer                  |
+      Dan heeft de response 10 personen
+
+    @fout-case
+    Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
+      Als personen wordt gezocht met de volgende parameters
+      | naam                          | waarde                               |
+      | type                          | ZoekMetNummeraanduidingIdentificatie |
+      | nummeraanduidingIdentificatie | 0518200000617227                     |
+      | inclusiefOverledenPersonen    | true                                 |
+      | fields                        | burgerservicenummer                  |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |

--- a/features/bevragen/zoek-met-postcode-en-huisnummer/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -61,7 +61,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetPostcodeEnHuisnummer
 
     @fout-case
     Scenario: Meer dan 10 personen gevonden
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam       | waarde                      |
       | type       | ZoekMetPostcodeEnHuisnummer |
       | postcode   | 2628HJ                      |
@@ -77,7 +77,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetPostcodeEnHuisnummer
       | instance | /haalcentraal/api/brp/personen                                            |
 
     Scenario: Verfijnde zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                       | waarde                      |
       | type                       | ZoekMetPostcodeEnHuisnummer |
       | postcode                   | 2628HJ                      |
@@ -88,7 +88,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetPostcodeEnHuisnummer
 
     @fout-case
     Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                       | waarde                      |
       | type                       | ZoekMetPostcodeEnHuisnummer |
       | postcode                   | 2628HJ                      |

--- a/features/bevragen/zoek-met-postcode-en-huisnummer/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -1,0 +1,106 @@
+#language: nl
+
+@gba
+Functionaliteit: maximaal aantal zoekresultaten ZoekMetPostcodeEnHuisnummer
+
+  Achtergrond:
+      Gegeven een adres heeft de volgende gegevens
+      | gemeentecode (92.10) | postcode (11.60) | huisnummer (11.20) | huisletter (11.30) |
+      | 0599                 | 2628HJ           | 2                  | A                  |
+      En de persoon met burgerservicenummer '000000001' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000002' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000003' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000004' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000005' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000006' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000007' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000008' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000009' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000010' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000011' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | O      |
+      En de persoon met burgerservicenummer '000000012' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | F      |
+      En de persoon met burgerservicenummer '000000013' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | postcode (11.60) | huisnummer (11.20) | huisletter (11.30) |
+      | 0599                 | 2628HJ           | 2                  | B                  |
+    
+
+  Rule: Wanneer er meer dan 10 personen gevonden worden bij zoeken wordt een foutmelding gegeven
+
+    @fout-case
+    Scenario: Meer dan 10 personen gevonden
+      Als personen wordt gezocht met de volgende parameters
+      | naam       | waarde                      |
+      | type       | ZoekMetPostcodeEnHuisnummer |
+      | postcode   | 2628HJ                      |
+      | huisnummer | 2                           |
+      | fields     | burgerservicenummer         |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |
+
+    Scenario: Verfijnde zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
+      Als personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                      |
+      | type                       | ZoekMetPostcodeEnHuisnummer |
+      | postcode                   | 2628HJ                      |
+      | huisnummer                 | 2                           |
+      | huisletter                 | A                           |
+      | fields                     | burgerservicenummer         |
+      Dan heeft de response 10 personen
+
+    @fout-case
+    Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
+      Als personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                      |
+      | type                       | ZoekMetPostcodeEnHuisnummer |
+      | postcode                   | 2628HJ                      |
+      | huisnummer                 | 2                           |
+      | huisletter                 | A                           |
+      | inclusiefOverledenPersonen | true                        |
+      | fields                     | burgerservicenummer         |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -61,7 +61,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetStraatHuisnummerEnGemeent
 
     @fout-case
     Scenario: Meer dan 10 personen gevonden
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                    | waarde                                           |
       | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
       | gemeenteVanInschrijving | 0599                                             |
@@ -78,7 +78,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetStraatHuisnummerEnGemeent
       | instance | /haalcentraal/api/brp/personen                                            |
 
     Scenario: Verfijnde zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                       | waarde                                           |
       | type                       | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
       | gemeenteVanInschrijving    | 0599                                             |
@@ -90,7 +90,7 @@ Functionaliteit: maximaal aantal zoekresultaten ZoekMetStraatHuisnummerEnGemeent
 
     @fout-case
     Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
-      Als personen wordt gezocht met de volgende parameters
+      Als gba personen wordt gezocht met de volgende parameters
       | naam                       | waarde                                           |
       | type                       | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
       | gemeenteVanInschrijving    | 0599                                             |

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/maximaal-aantal-zoekresultaten-gba.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/maximaal-aantal-zoekresultaten-gba.feature
@@ -1,0 +1,109 @@
+#language: nl
+
+@gba
+Functionaliteit: maximaal aantal zoekresultaten ZoekMetStraatHuisnummerEnGemeenteVanInschrijving
+
+  Achtergrond:
+      Gegeven een adres heeft de volgende gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) | huisletter (11.30) |
+      | 0599                 | Afrikanerplein     | 2                  | A                  |
+      En de persoon met burgerservicenummer '000000001' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000002' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000003' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000004' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000005' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000006' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000007' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000008' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000009' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000010' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon met burgerservicenummer '000000011' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | O      |
+      En de persoon met burgerservicenummer '000000012' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | naam                                 | waarde |
+      | reden opschorting bijhouding (67.20) | F      |
+      En een adres heeft de volgende gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) | huisletter (11.30) |
+      | 0599                 | Afrikanerplein     | 2                  | B                  |
+      En de persoon met burgerservicenummer '000000013' is ingeschreven op het adres met de volgende gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+    
+
+  Rule: Wanneer er meer dan 10 personen gevonden worden bij zoeken wordt een foutmelding gegeven
+
+    @fout-case
+    Scenario: Meer dan 10 personen gevonden
+      Als personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                                           |
+      | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving | 0599                                             |
+      | straat                  | Afrikanerplein                                   |
+      | huisnummer              | 2                                                |
+      | fields                  | burgerservicenummer                              |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |
+
+    Scenario: Verfijnde zoekopdracht vindt exact 10 personen omdat overleden personen en afgevoerde persoonslijsten niet worden geleverd
+      Als personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                                           |
+      | type                       | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving    | 0599                                             |
+      | straat                     | Afrikanerplein                                   |
+      | huisnummer                 | 2                                                |
+      | huisletter                 | A                                                |
+      | fields                     | burgerservicenummer                              |
+      Dan heeft de response 10 personen
+
+    @fout-case
+    Scenario: Meer dan 10 personen omdat ook overleden personen gezocht is
+      Als personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                                           |
+      | type                       | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving    | 0599                                             |
+      | straat                     | Afrikanerplein                                   |
+      | huisnummer                 | 2                                                |
+      | huisletter                 | A                                                |
+      | inclusiefOverledenPersonen | true                                             |
+      | fields                     | burgerservicenummer                              |
+      Dan heeft de response een object met de volgende gegevens
+      | naam     | waarde                                                                    |
+      | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1               |
+      | title    | Teveel zoekresultaten.                                                    |
+      | status   | 400                                                                       |
+      | detail   | Meer dan maximum van 10 zoekresultaten gevonden. Verfijn de zoekopdracht. |
+      | code     | tooManyResults                                                            |
+      | instance | /haalcentraal/api/brp/personen                                            |

--- a/features/step_definitions/step_defs.js
+++ b/features/step_definitions/step_defs.js
@@ -330,22 +330,24 @@ After(async function() {
     try {
         client = await pool.connect();
 
-        let adresData;
+        let adresData = [];
 
         for(const sqlData of this.context.sqlData) {
             if (equals(sqlData, ['adres', 'ids'])) {
-                adresData = sqlData;
+                adresData.push(sqlData);
             }
             else {
-                if (adresData !== undefined &&
-                    adresData.ids.adres_id == sqlData.ids.adres_id) {
-                        sqlData.ids.adres_id = undefined;
-                    }
+                if(adresData.find(adrData => adrData.ids.adres_id === sqlData.ids.adres_id)) {
+                    sqlData.ids.adres_id = undefined;
+                }
+
                 await deleteRecords(client, sqlData);
             }
         }
 
-        await deleteAdresRecord(client, adresData);
+        for(const adrData of adresData) {
+            await deleteAdresRecord(client, adrData);
+        }
         await deleteAutorisatieRecords(client);
     }
     catch(ex) {


### PR DESCRIPTION
features die testen dat het maximaal aantal zoekresultaten is beperkt (nu gezet op 10).

Deze scenario's falen nog. De implementatie lijkt overleden personen en afgevoerde PL-en mee te tellen in dit aantal, terwijl die niet geleverd worden.

@MelvLee features ZoekMetNummeraanduidingIdentificatie en ZoekMetStraatHuisnummerEnGemeenteVanInschrijving zullen bij de eerste keer uitvoeren goed gaan (behalve dat ze falen op bovenstaande), maar bij een tweede keer uitvoeren komt een duplicate key value violates unique constraint "lo3_adres_idx_0" foutmelding.

Feature ZoekMetPostcodeEnHuisnummer heeft hiervoor een work around. Die work around zou voor ZoekMetNummeraanduidingIdentificatie niet werken, omdat hier op twee verschillende adressen meerdere bewoners moeten zijn.