### PR TITLE
scenario gba leveren adressering

### DIFF
--- a/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/fields-gba.feature
+++ b/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/fields-gba.feature
@@ -503,7 +503,7 @@ Rule: wanneer één of meerdere adresregel velden voor een persoon wordt gevraag
     | 088500                  | hele groep geldigheid              | adressering.adresregel1,adressering.land                                                 |
     | 088510                  | datum ingang geldigheid            | adressering.adresregel1,adressering.adresregel2                                          |
 
-Rule: wanneer groep adressering wordt gevraagd bij zoeken, dan worden de adresgegevens geleverd en iet naam of partner
+Rule: wanneer groep adressering wordt gevraagd bij zoeken, dan worden de adresgegevens geleverd en niet naam of partner
   
   Scenario: adressering is gevraagd 
       Gegeven de persoon met burgerservicenummer '000000139' heeft de volgende gegevens

--- a/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/fields-gba.feature
+++ b/features/bevragen/persoon-beperkt/adressering/adres-regels/dev/fields-gba.feature
@@ -502,3 +502,51 @@ Rule: wanneer één of meerdere adresregel velden voor een persoon wordt gevraag
     | 081420                  | datum vestiging in Nederland       | adressering.adresregel3,adressering.land                                                 |
     | 088500                  | hele groep geldigheid              | adressering.adresregel1,adressering.land                                                 |
     | 088510                  | datum ingang geldigheid            | adressering.adresregel1,adressering.adresregel2                                          |
+
+Rule: wanneer groep adressering wordt gevraagd bij zoeken, dan worden de adresgegevens geleverd en iet naam of partner
+  
+  Scenario: adressering is gevraagd 
+      Gegeven de persoon met burgerservicenummer '000000139' heeft de volgende gegevens
+      | naam                                 | waarde    |
+      | geslachtsaanduiding (04.10)          | M         |
+      | voornamen (02.10)                    | Jan Peter |
+      | adellijke titel of predicaat (02.20) | JH        |
+      | voorvoegsel (02.30)                  | te        |
+      | geslachtsnaam (02.40)                | Hoogh     |
+      | aanduiding naamgebruik (61.10)       | E         |
+      | geboortedatum (03.10)                | 19830526  |
+      En de persoon heeft een 'partner' met de volgende gegevens
+      | naam                                                               | waarde         |
+      | voornamen (02.10)                                                  | Anna Catharina |
+      | adellijke titel of predicaat (02.20)                               | BS             |
+      | voorvoegsel (02.30)                                                | van den        |
+      | geslachtsnaam (02.40)                                              | Aedel          |
+      | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 20010809       |
+      En de 'partner' is gewijzigd naar de volgende gegevens
+      | naam                                                         | waarde         |
+      | voornamen (02.10)                                            | Anna Catharina |
+      | adellijke titel of predicaat (02.20)                         | BS             |
+      | voorvoegsel (02.30)                                          | van den        |
+      | geslachtsnaam (02.40)                                        | Aedel          |
+      | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 20211109       |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0518                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | straatnaam (11.10)       | huisnummer (11.20) | postcode (11.60) |
+      | 0518                 | Jonkheer van Riemsdijkln | 88                 | 2583XL           |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Hoogh                               |
+      | geboortedatum | 1983-05-26                          |
+      | fields        | adressering                         |
+      Dan heeft de response een persoon met de volgende gegevens
+      | naam                                 | waarde        |
+      | gemeenteVanInschrijving.code         | 0518          |
+      | gemeenteVanInschrijving.omschrijving | 's-Gravenhage |
+      En heeft de persoon de volgende 'verblijfplaats' gegevens
+      | naam       | waarde                   |
+      | straat     | Jonkheer van Riemsdijkln |
+      | huisnummer | 88                       |
+      | postcode   | 2583XL                   |

--- a/features/bevragen/persoon-beperkt/rni/dev/overzicht-gba.feature
+++ b/features/bevragen/persoon-beperkt/rni/dev/overzicht-gba.feature
@@ -162,11 +162,51 @@ Rule: RNI-deelnemer gegevens die horen bij categorie 01 (Persoon) en/of 08 (Verb
 
     Voorbeelden:
     | fields                                                                |
-    | adressering                                                           |
     | naam,adressering.adresregel1                                          |
     | naam.voornamen,naam.geslachtsnaam,adressering.land.omschrijving       |
     | naam,adressering.adresregel2                                          |
     | naam,adressering.adresregel1,adressering.adresregel2,adressering.land |
+
+  Abstract Scenario: persoon heeft RNI-deelnemer gegevens voor categoriën persoon en verblijfplaats en adressering wordt gevraagd
+    Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+    | naam                         | waarde                                      |
+    | voornamen (02.10)            | Peter                                       |
+    | geslachtsnaam (02.40)        | Jansen                                      |
+    | geboortedatum (03.10)        | 19830526                                    |
+    | rni-deelnemer (88.10)        | 0101                                        |
+    | omschrijving verdrag (88.20) | Belastingverdrag tussen België en Nederland |
+    En de persoon heeft de volgende 'verblijfplaats' gegevens
+    | naam                         | waarde                               |
+    | land (13.10)                 | 5010                                 |
+    | rni-deelnemer (88.10)        | 0201                                 |
+    | omschrijving verdrag (88.20) | Artikel 45 EU-Werkingsverdrag (VWEU) |
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam          | waarde                              |
+    | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam | Jansen                              |
+    | geboortedatum | 1983-05-26                          |
+    | fields        | <fields>                            |
+    Dan heeft de response een persoon met de volgende 'verblijfplaats' gegevens
+    | naam              | waarde |
+    | land.code         | 5010   |
+    | land.omschrijving | België |
+    En heeft de persoon een 'rni' met de volgende gegevens
+    | naam                   | waarde                                            |
+    | deelnemer.code         | 0201                                              |
+    | deelnemer.omschrijving | Sociale Verzekeringsbank (inzake AOW, Anw en AKW) |
+    | omschrijvingVerdrag    | Artikel 45 EU-Werkingsverdrag (VWEU)              |
+    | categorie              | Verblijfplaats                                    |
+
+    Voorbeelden:
+    | fields                                                           |
+    | adressering.adresregel1                                          |
+    | adressering.adresregel2                                          |
+    | adressering.adresregel3                                          |
+    | adressering.land                                                 |
+    | adressering.land.code                                            |
+    | adressering.land.omschrijving                                    |
+    | adressering.adresregel1,adressering.adresregel2,adressering.land |
+    | adressering                                                      |
     
   Abstract Scenario: persoon heeft RNI-deelnemer gegevens voor verblijfplaats, maar er worden geen verblijfplaats velden gevraagd
     Gegeven de persoon met burgerservicenummer '000000036' heeft de volgende gegevens


### PR DESCRIPTION
scenario dat test dat bij zoeken (persoonBeperkt) en met fields vragen om adressering alleen de adresvelden worden geleverd. Op dit moment wordt ook nog de naam en geboortedatum geleverd.