### PR TITLE
wijziging scenario meer dan 1 foute parameter die nu ondersteund wordt

### DIFF
--- a/features/bevragen/zoek-met-postcode-en-huisnummer/dev/fout-cases-gba.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/dev/fout-cases-gba.feature
@@ -195,7 +195,7 @@ Rule: een postcode is een string bestaande uit 4 cijfers, 0 of 1 spatie en 2 let
     | naam       | waarde                      |
     | type       | ZoekMetPostcodeEnHuisnummer |
     | postcode   | 0628HJ                      |
-    | huisnummer | twee                        |
+    | huisnummer | 0                           |
     | fields     | burgerservicenummer         |
     Dan heeft de response een object met de volgende gegevens
     | naam     | waarde                                                      |
@@ -208,7 +208,7 @@ Rule: een postcode is een string bestaande uit 4 cijfers, 0 of 1 spatie en 2 let
     En heeft het object de volgende 'invalidParams' gegevens
     | code    | name       | reason                                                             |
     | pattern | postcode   | Waarde voldoet niet aan patroon ^[1-9]{1}[0-9]{3}[ ]?[A-Za-z]{2}$. |
-    | integer | huisnummer | Waarde is geen geldig getal.                                       |
+    | minimum | huisnummer | Waarde is lager dan minimum 1.                                     |
 
 Rule: een huisletter is een string bestaande uit 1 letter (niet hoofdlettergevoelig)
 


### PR DESCRIPTION
n.a.v. #1598 

> ##### Meerdere type validatie foutmeldingen is teveel van het goede op dit moment.
> - [ ] Scenario: Meerdere ongeldige parameters zijn opgegeven # features\bevragen\zoek-met-postcode-en-huisnummer\dev\fout-cases-gba.feature:193

Gewijzigd zodat 2 fouten op zelfde niveau veroorzaakt worden