### PR TITLE
Scenario ouder-partner-kind met alleen onderzoek

### DIFF
--- a/features/bevragen/persoon/kind/dev/kinderen-gba.feature
+++ b/features/bevragen/persoon/kind/dev/kinderen-gba.feature
@@ -118,6 +118,24 @@ Functionaliteit: kinderen raadplegen
       | fields              | kinderen.burgerservicenummer    |
       Dan heeft de response een persoon met een 'kind' zonder gegevens
 
+    Scenario: Geen kind, maar dat wordt wel onderzocht
+      Gegeven de persoon met burgerservicenummer '000000061' heeft een 'kind' met de volgende gegevens
+      | naam                            | waarde           |
+      | gemeente document (82.10)       | 0518             |
+      | datum document (82.20)          | 20040105         |
+      | aanduiding in onderzoek (83.10) | 090000           |
+      | datum ingang onderzoek (83.20)  | 20230114         |
+      | beschrijving document (82.30)   | D27894-2004-A782 |
+      | ingangsdatum geldigheid (85.10) | 20031107         |
+      | datum van opneming (86.10)      | 20040112         |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000061                       |
+      | fields              | kinderen                        |
+      Dan heeft de response een persoon zonder 'kind' gegevens
+
+
   Rule: de geleverde kindgegevens zijn de gegevens zoals die staan op de persoonslijst van de gevraagde persoon
     Bij het raadplegen van een persoon worden alleen gegevens uit de persoonslijst van de gevraagde persoon gebruikt, en nooit gegevens van de persoonslijst van het kind
 

--- a/features/bevragen/persoon/ouder/dev/ouders-gba.feature
+++ b/features/bevragen/persoon/ouder/dev/ouders-gba.feature
@@ -183,7 +183,7 @@ Rule: Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenome
     | 20190614                                           | .                     | V                           |
     En de persoon heeft een ouder '2' met de volgende gegevens
     | aktenummer (81.20) | datum ingang geldigheid (85.10) |
-    | 2•E0001            | 20160518                        |
+    | 12 AB3456CD        | 20160518                        |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
@@ -203,7 +203,7 @@ Rule: Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenome
     | 20190614                                           | .                     | V                           |
     En de persoon heeft een ouder '2' met de volgende gegevens
     | aktenummer (81.20) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) | datum ingang geldigheid (85.10) |
-    | 2•E0001            | 030000                          | 20230114                       | 20160518                        |
+    | 12 AB3456CD        | 030000                          | 20230114                       | 20160518                        |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
@@ -223,7 +223,7 @@ Rule: Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenome
     | .                     | 00000000                                           |
     En de persoon heeft een ouder '2' met de volgende gegevens
     | aktenummer (81.20) | datum ingang geldigheid (85.10) |
-    | 2•E0001            | 20160518                        |
+    | 12 AB3456CD        | 20160518                        |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
@@ -241,7 +241,7 @@ Rule: Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenome
     | Jansen                | V                           | 20190614                                           |
     En de persoon heeft een ouder '2' met de volgende gegevens
     | aktenummer (81.20) | datum ingang geldigheid (85.10) |
-    | 2•E0001            | 20160518                        |
+    | 12 AB3456CD        | 20160518                        |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
@@ -269,7 +269,7 @@ Rule: Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenome
   Scenario: ouder 1 met alleen gegevens in groepen 81 en 85 en geen ouder 2
     Gegeven de persoon met burgerservicenummer '000000255' heeft een ouder '1' met de volgende gegevens
     | aktenummer (81.20) | datum ingang geldigheid (85.10) |
-    | 2•E0001            | 20160518                        |
+    | 12 AB3456CD        | 20160518                        |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |

--- a/features/bevragen/persoon/ouder/dev/ouders-gba.feature
+++ b/features/bevragen/persoon/ouder/dev/ouders-gba.feature
@@ -197,6 +197,26 @@ Rule: Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenome
     | geslacht.omschrijving                   | vrouw    |
     | datumIngangFamilierechtelijkeBetrekking | 20190614 |
 
+  Scenario: Geen ouder met ouderaanduiding "2" maar dat wordt wel onderzocht
+    Gegeven de persoon met burgerservicenummer '000000231' heeft een ouder '1' met de volgende gegevens
+    | datum ingang familierechtelijke betrekking (62.10) | geslachtsnaam (02.40) | geslachtsaanduiding (04.10) |
+    | 20190614                                           | .                     | V                           |
+    En de persoon heeft een ouder '2' met de volgende gegevens
+    | aktenummer (81.20) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) | datum ingang geldigheid (85.10) |
+    | 2•E0001            | 030000                          | 20230114                       | 20160518                        |
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 000000231                       |
+    | fields              | ouders                          |
+    Dan heeft de response een persoon met een 'ouder' met de volgende gegevens
+    | naam                                    | waarde   |
+    | ouderAanduiding                         | 1        |
+    | naam.geslachtsnaam                      | .        |
+    | geslacht.code                           | V        |
+    | geslacht.omschrijving                   | vrouw    |
+    | datumIngangFamilierechtelijkeBetrekking | 20190614 |
+
   Scenario: volledig onbekende ouder
     Gegeven de persoon met burgerservicenummer '000000243' heeft een ouder '1' met de volgende gegevens
     | geslachtsnaam (02.40) | datum ingang familierechtelijke betrekking (62.10) |

--- a/features/bevragen/persoon/ouder/ouders.feature
+++ b/features/bevragen/persoon/ouder/ouders.feature
@@ -186,7 +186,7 @@ Rule: Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenome
     | 20190614                                           | .                     | V                           |
     En de persoon heeft een ouder '2' met de volgende gegevens
     | aktenummer (81.20) | datum ingang geldigheid (85.10) |
-    | 2•E0001            | 20160518                        |
+    | 12 AB3456CD        | 20160518                        |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
@@ -208,7 +208,7 @@ Rule: Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenome
     | .                     | 00000000                                           |
     En de persoon heeft een ouder '2' met de volgende gegevens
     | aktenummer (81.20) | datum ingang geldigheid (85.10) |
-    | 2•E0001            | 20160518                        |
+    | 12 AB3456CD        | 20160518                        |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
@@ -228,7 +228,7 @@ Rule: Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenome
     | Jansen                | V                           | 20190614                                           |
     En de persoon heeft een ouder '2' met de volgende gegevens
     | aktenummer (81.20) | datum ingang geldigheid (85.10) |
-    | 2•E0001            | 20160518                        |
+    | 12 AB3456CD        | 20160518                        |
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |

--- a/features/bevragen/persoon/partner/dev/overzicht-gba.feature
+++ b/features/bevragen/persoon/partner/dev/overzicht-gba.feature
@@ -170,6 +170,23 @@ Rule: Een partner wordt alleen teruggegeven als minimaal één gegeven in de ide
     | fields              | partners                        |
     Dan heeft de response een persoon zonder 'partner' gegevens
 
+  Scenario: Geen partner, maar dat wordt wel onderzocht
+    Gegeven de persoon met burgerservicenummer '000000061' heeft een 'partner' met de volgende gegevens
+    | naam                            | waarde           |
+    | gemeente document (82.10)       | 0518             |
+    | datum document (82.20)          | 20040105         |
+    | aanduiding in onderzoek (83.10) | 050000           |
+    | datum ingang onderzoek (83.20)  | 20230114         |
+    | beschrijving document (82.30)   | D27894-2004-A782 |
+    | ingangsdatum geldigheid (85.10) | 20031107         |
+    | datum van opneming (86.10)      | 20040112         |
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 000000061                       |
+    | fields              | partners                        |
+    Dan heeft de response een persoon zonder 'partner' gegevens
+
 
 Rule: Wanneer er meerdere actuele (niet-ontbonden) huwelijken/partnerschappen zijn, worden die allemaal geleverd
 


### PR DESCRIPTION
Bij ouders, partners en kinderen scenario waarbij getest wordt dat wanneer alleen inOnderzoek een waarde heeft en de andere gegevens niet, de ouder/partner/kind niet geleverd wordt.

Op dit moment is dat hoe het werkt voor ouders, maar bij partners en kinderen wordt dan een partner/kind geleverd met alleen de onderzoeksgegevens. Dit hoort voor alle relaties op dezelfde manier te werken, volgens de beschreven rule Wanneer alleen gegevens in groep 81, 82, 83, 84, 85 en/of 86 zijn opgenomen en geen gegevens in groep 1, 2, 3, 4 enz., dan wordt de ouder/partner/kind niet opgenomen.