### PR TITLE
Scenario voor wel leveren gevraagde gegevens bij andere reden dan F

### DIFF
--- a/features/bevragen/persoon-beperkt/opschorting-bijhouding/overzicht.feature
+++ b/features/bevragen/persoon-beperkt/opschorting-bijhouding/overzicht.feature
@@ -106,6 +106,101 @@ Rule: personen met afgevoerde persoonslijst worden niet gevonden bij het zoeken
     | true                         | inclusief                    |
     | false                        | exclusief                    |
 
+
+Rule: personen op een logisch verwijderde persoonslijst worden niet gevonden bij het zoeken
+
+  Abstract Scenario: persoon opgeschort met reden "W" (wissen) wordt gezocht met geslachtsnaam en geboortedatum <zoek overleden personen type> overleden personen
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | 20220829                             | W                                    |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                       | waarde                              |
+    | type                       | ZoekMetGeslachtsnaamEnGeboortedatum |
+    | geslachtsnaam              | Vries                               |
+    | geboortedatum              | 2004-05-26                          |
+    | inclusiefOverledenPersonen | <inclusief overleden personen>      |
+    | fields                     | burgerservicenummer                 |
+    Dan heeft de response 0 personen
+
+    Voorbeelden:
+    | inclusief overleden personen | zoek overleden personen type |
+    | true                         | inclusief                    |
+    | false                        | exclusief                    |
+
+  Abstract Scenario: persoon opgeschort met reden "W" (wissen) wordt gezocht met geslachtsnaam, voornamen en gemeente van inschrijving <zoek overleden personen type> overleden personen
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | 20220829                             | W                                    |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                       | waarde                               |
+    | type                       | ZoekMetNaamEnGemeenteVanInschrijving |
+    | geslachtsnaam              | Vries                                |
+    | voornamen                  | William                              |
+    | gemeenteVanInschrijving    | 0530                                 |
+    | inclusiefOverledenPersonen | <inclusief overleden personen>       |
+    | fields                     | burgerservicenummer                  |
+    Dan heeft de response 0 personen
+
+    Voorbeelden:
+    | inclusief overleden personen | zoek overleden personen type |
+    | true                         | inclusief                    |
+    | false                        | exclusief                    |
+
+  Abstract Scenario: persoon opgeschort met reden "W" (wissen) wordt gezocht met nummeraanduiding identificatie <zoek overleden personen type> overleden personen
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | 20220829                             | W                                    |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                          | waarde                               |
+    | type                          | ZoekMetNummeraanduidingIdentificatie |
+    | nummeraanduidingIdentificatie | 0599200000219679                     |
+    | inclusiefOverledenPersonen    | <inclusief overleden personen>       |
+    | fields                        | burgerservicenummer                  |
+    Dan heeft de response 0 personen
+
+    Voorbeelden:
+    | inclusief overleden personen | zoek overleden personen type |
+    | true                         | inclusief                    |
+    | false                        | exclusief                    |
+
+  Abstract Scenario: persoon opgeschort met reden "W" (wissen) wordt gezocht met postcode en huisnummer <zoek overleden personen type> overleden personen
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | 20220829                             | W                                    |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                       | waarde                         |
+    | type                       | ZoekMetPostcodeEnHuisnummer    |
+    | postcode                   | 1628HJ                         |
+    | huisnummer                 | 31                             |
+    | inclusiefOverledenPersonen | <inclusief overleden personen> |
+    | fields                     | burgerservicenummer            |
+    Dan heeft de response 0 personen
+
+    Voorbeelden:
+    | inclusief overleden personen | zoek overleden personen type |
+    | true                         | inclusief                    |
+    | false                        | exclusief                    |
+
+  Abstract Scenario: persoon opgeschort met reden "W" (wissen) wordt gezocht met straat, huisnummer en gemeente van inschrijving <zoek overleden personen type> overleden personen
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | 20220829                             | W                                    |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                       | waarde                                           |
+    | type                       | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+    | gemeenteVanInschrijving    | 0530                                             |
+    | straat                     | Haagse Reigerstraat                              |
+    | huisnummer                 | 31                                               |
+    | inclusiefOverledenPersonen | <inclusief overleden personen>                   |
+    | fields                     | burgerservicenummer                              |
+    Dan heeft de response 0 personen
+
+    Voorbeelden:
+    | inclusief overleden personen | zoek overleden personen type |
+    | true                         | inclusief                    |
+    | false                        | exclusief                    |
+
+
 Rule: De optionele 'inclusiefOverledenPersonen' parameter moet worden opgegeven om een overleden persoon te kunnen vinden
 
   Scenario: persoon opgeschort met reden "O" (overlijden) wordt gezocht met geslachtsnaam en geboortedatum exclusief overleden personen

--- a/features/bevragen/persoon/opschorting-bijhouding/dev/afgevoerde-pl-gba.feature
+++ b/features/bevragen/persoon/opschorting-bijhouding/dev/afgevoerde-pl-gba.feature
@@ -113,22 +113,31 @@ Rule: bij het raadplegen van een persoon met afgevoerde persoonslijst wordt de r
     | verblijfplaatsBinnenland                                                      |
     | verblijfplaats.datumVan.datum,verblijfplaats.verblijfadres.woonplaats         |
 
-  Scenario: geraadpleegde persoon is opgeschort met andere reden dan "F"
+  Abstract Scenario: geraadpleegde persoon is opgeschort met andere reden dan "F"
     Gegeven de persoon met burgerservicenummer '000000048' heeft de volgende gegevens
     | voornamen (02.10) |
     | William           |
     En de persoon heeft de volgende 'inschrijving' gegevens
     | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
-    | 20220829                             | X                                    |
+    | 20220829                             | <reden>                              |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 000000048                       |
     | fields              | naam                            |
     Dan heeft de response een persoon met de volgende 'opschortingBijhouding' gegevens
-    | naam       | waarde   |
-    | reden.code | X        |
-    | datum      | 20220829 |
+    | naam               | waarde         |
+    | reden.code         | <reden>        |
+    | reden.omschrijving | <omschrijving> |
+    | datum              | 20220829       |
     En heeft de persoon de volgende 'naam' gegevens
     | naam      | waarde  |
     | voornamen | William |
+
+    Voorbeelden:
+    | reden | omschrijving              |
+    | O     | overlijden                |
+    | E     | emigratie                 |
+    | M     | ministerieel besluit      |
+    | R     | pl is aangelegd in de rni |
+    | X     |                           |

--- a/features/bevragen/persoon/opschorting-bijhouding/dev/afgevoerde-pl-gba.feature
+++ b/features/bevragen/persoon/opschorting-bijhouding/dev/afgevoerde-pl-gba.feature
@@ -112,3 +112,23 @@ Rule: bij het raadplegen van een persoon met afgevoerde persoonslijst wordt de r
     | adresseringBinnenland                                                         |
     | verblijfplaatsBinnenland                                                      |
     | verblijfplaats.datumVan.datum,verblijfplaats.verblijfadres.woonplaats         |
+
+  Scenario: geraadpleegde persoon is opgeschort met andere reden dan "F"
+    Gegeven de persoon met burgerservicenummer '000000048' heeft de volgende gegevens
+    | voornamen (02.10) |
+    | William           |
+    En de persoon heeft de volgende 'inschrijving' gegevens
+    | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+    | 20220829                             | X                                    |
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 000000048                       |
+    | fields              | naam                            |
+    Dan heeft de response een persoon met de volgende 'opschortingBijhouding' gegevens
+    | naam       | waarde   |
+    | reden.code | X        |
+    | datum      | 20220829 |
+    En heeft de persoon de volgende 'naam' gegevens
+    | naam      | waarde  |
+    | voornamen | William |

--- a/features/bevragen/persoon/opschorting-bijhouding/dev/afgevoerde-pl-gba.feature
+++ b/features/bevragen/persoon/opschorting-bijhouding/dev/afgevoerde-pl-gba.feature
@@ -140,4 +140,3 @@ Rule: bij het raadplegen van een persoon met afgevoerde persoonslijst wordt de r
     | E     | emigratie                 |
     | M     | ministerieel besluit      |
     | R     | pl is aangelegd in de rni |
-    | X     |                           |

--- a/features/bevragen/raadpleeg-met-burgerservicenummer/dev/opschorting-bijhouding-gba.feature
+++ b/features/bevragen/raadpleeg-met-burgerservicenummer/dev/opschorting-bijhouding-gba.feature
@@ -1,0 +1,59 @@
+#language: nl
+
+@gba
+Functionaliteit: RaadpleegMetBurgerservicenummer van persoonslijst met opschorting bijhouding
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "W" (wissen) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "W"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | W                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                       |
+      | fields              | burgerservicenummer             |
+      Dan heeft de response 0 personen
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "W" en zelfde burgerservicenummer is gebruikt op andere persoonslijst
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) |
+      | Maassen               |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | W                                    |
+      En de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) |
+      | Rafi                  |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                                 |
+      | type                | RaadpleegMetBurgerservicenummer        |
+      | burgerservicenummer | 000000024                              |
+      | fields              | burgerservicenummer,naam.geslachtsnaam |
+      Dan heeft de response 1 persoon
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000024 |
+      | naam.geslachtsnaam  | Rafi      |
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "<opschorting>"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | <opschorting>                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000024                       |
+      | fields              | burgerservicenummer             |
+      Dan heeft de response 1 persoon
+
+      Voorbeelden:
+      | opschorting | omschrijving              |
+      | O           | overlijden                |
+      | E           | emigratie                 |
+      | M           | ministerieel besluit      |
+      | R           | pl is aangelegd in de rni |
+      | F           | fout                      |
+      | .           | onbekend                  |
+

--- a/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/opschorting-bijhouding-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-en-geboortedatum/dev/opschorting-bijhouding-gba.feature
@@ -1,0 +1,142 @@
+#language: nl
+
+@gba
+Functionaliteit: ZoekMetGeslachtsnaamEnGeboortedatum van persoonslijst met opschorting bijhouding
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "W" (wissen) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "W"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) |
+      | 19830526              | Maassen               |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | W                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Maassen                             |
+      | geboortedatum | 1983-05-26                          |
+      | fields        | burgerservicenummer                 |
+      Dan heeft de response 0 personen
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "W"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) |
+      | 19830526              | Maassen               |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | W                                    |
+      En de persoon met burgerservicenummer '000000048' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) |
+      | 19830526              | Maassen               |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Maassen                             |
+      | geboortedatum | 1983-05-26                          |
+      | fields        | burgerservicenummer                 |
+      Dan heeft de response 1 persoon
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000048 |
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "F" (fout) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "F"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) |
+      | 19830526              | Maassen               |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | F                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Maassen                             |
+      | geboortedatum | 1983-05-26                          |
+      | fields        | burgerservicenummer                 |
+      Dan heeft de response 0 personen
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "F"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) |
+      | 19830526              | Maassen               |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | F                                    |
+      En de persoon met burgerservicenummer '000000048' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) |
+      | 19830526              | Maassen               |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Maassen                             |
+      | geboortedatum | 1983-05-26                          |
+      | fields        | burgerservicenummer                 |
+      Dan heeft de response 1 persoon
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000048 |
+
+  Rule: Een persoonslijst met reden opschorting bijhouding ongelijk aan "O" (overleden) wordt alleen gevonden bij gebruik van parameter inclusiefOverledenPersonen met waarde true
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen wordt niet gebruikt
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) |
+      | 19830526              | Maassen               |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                              |
+      | type                       | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam              | Maassen                             |
+      | geboortedatum              | 1983-05-26                          |
+      | fields                     | burgerservicenummer                 |
+      Dan heeft de response 0 personen
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen heeft waarde <inclusiefOverledenPersonen>
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) |
+      | 19830526              | Maassen               |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                              |
+      | type                       | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam              | Maassen                             |
+      | geboortedatum              | 1983-05-26                          |
+      | fields                     | burgerservicenummer                 |
+      | inclusiefOverledenPersonen | <inclusiefOverledenPersonen>        |
+      Dan heeft de response <aantal gevonden personen> persoon
+
+      Voorbeelden:
+      | inclusiefOverledenPersonen | aantal gevonden personen |
+      | false                      | 0                        |
+      | true                       | 1                        |
+
+  Rule: Een persoonslijst met overige reden opschorting bijhouding kan wel worden gevonden en geleverd
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "<opschorting>"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geboortedatum (03.10) | geslachtsnaam (02.40) |
+      | 19830526              | Maassen               |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | <opschorting>                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam          | waarde                              |
+      | type          | ZoekMetGeslachtsnaamEnGeboortedatum |
+      | geslachtsnaam | Maassen                             |
+      | geboortedatum | 1983-05-26                          |
+      | fields        | burgerservicenummer                 |
+      Dan heeft de response 1 persoon
+
+      Voorbeelden:
+      | opschorting | omschrijving              |
+      | E           | emigratie                 |
+      | M           | ministerieel besluit      |
+      | R           | pl is aangelegd in de rni |
+      | .           | onbekend                  |

--- a/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/opschorting-bijhouding-gba.feature
+++ b/features/bevragen/zoek-met-geslachtsnaam-voornamen-en-gemeente-van-inschrijving/dev/opschorting-bijhouding-gba.feature
@@ -1,0 +1,176 @@
+#language: nl
+
+@gba
+Functionaliteit: ZoekMetNaamEnGemeenteVanInschrijving van persoonslijst met opschorting bijhouding
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "W" (wissen) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "W"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) |
+      | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | W                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                               |
+      | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving | 0014                                 |
+      | geslachtsnaam           | Maassen                              |
+      | voornamen               | Pieter                               |
+      | fields                  | burgerservicenummer                  |
+      Dan heeft de response 0 personen
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "W"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) |
+      | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | W                                    |
+      En de persoon met burgerservicenummer '000000048' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) | voorvoegsel (02.30) |
+      | Maassen               | Pieter            | van                 |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                               |
+      | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving | 0014                                 |
+      | geslachtsnaam           | Maassen                              |
+      | voornamen               | Pieter                               |
+      | fields                  | burgerservicenummer                  |
+      Dan heeft de response 1 persoon
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000048 |
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "F" (fout) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "F"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) |
+      | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | F                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                               |
+      | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving | 0014                                 |
+      | geslachtsnaam           | Maassen                              |
+      | voornamen               | Pieter                               |
+      | fields                  | burgerservicenummer                  |
+      Dan heeft de response 0 personen
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "F"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) |
+      | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | F                                    |
+      En de persoon met burgerservicenummer '000000048' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) |
+      | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                               |
+      | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving | 0014                                 |
+      | geslachtsnaam           | Maassen                              |
+      | voornamen               | Pieter                               |
+      | fields                  | burgerservicenummer                  |
+      Dan heeft de response 1 persoon
+      En heeft de response een persoon met de volgende gegevens
+      | naam                | waarde    |
+      | burgerservicenummer | 000000048 |
+
+  Rule: Een persoonslijst met reden opschorting bijhouding ongelijk aan "O" (overleden) wordt alleen gevonden bij gebruik van parameter inclusiefOverledenPersonen met waarde true
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen wordt niet gebruikt
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) |
+      | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                               |
+      | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving | 0014                                 |
+      | geslachtsnaam           | Maassen                              |
+      | voornamen               | Pieter                               |
+      | fields                  | burgerservicenummer                  |
+      Dan heeft de response 0 personen
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen heeft waarde <inclusiefOverledenPersonen>
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) |
+      | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                               |
+      | type                       | ZoekMetNaamEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving    | 0014                                 |
+      | geslachtsnaam              | Maassen                              |
+      | voornamen                  | Pieter                               |
+      | fields                     | burgerservicenummer                  |
+      | inclusiefOverledenPersonen | <inclusiefOverledenPersonen>         |
+      Dan heeft de response <aantal gevonden personen> persoon
+
+      Voorbeelden:
+      | inclusiefOverledenPersonen | aantal gevonden personen |
+      | false                      | 0                        |
+      | true                       | 1                        |
+
+  Rule: Een persoonslijst met overige reden opschorting bijhouding kan wel worden gevonden en geleverd
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "<opschorting>"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende gegevens
+      | geslachtsnaam (02.40) | voornamen (02.10) |
+      | Maassen               | Pieter            |
+      En de persoon heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0014                              |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | <opschorting>                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                               |
+      | type                    | ZoekMetNaamEnGemeenteVanInschrijving |
+      | gemeenteVanInschrijving | 0014                                 |
+      | geslachtsnaam           | Maassen                              |
+      | voornamen               | Pieter                               |
+      | fields                  | burgerservicenummer                  |
+      Dan heeft de response 1 persoon
+
+      Voorbeelden:
+      | opschorting | omschrijving              |
+      | E           | emigratie                 |
+      | M           | ministerieel besluit      |
+      | R           | pl is aangelegd in de rni |
+      | .           | onbekend                  |

--- a/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/opschorting-bijhouding-gba.feature
+++ b/features/bevragen/zoek-met-nummeraanduiding-identificatie/dev/opschorting-bijhouding-gba.feature
@@ -1,0 +1,113 @@
+#language: nl
+
+@gba
+Functionaliteit: ZoekMetNummeraanduidingIdentificatie van persoonslijst met opschorting bijhouding
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "W" (wissen) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "W"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0599                 | 0599200000219679                           |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | W                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                          | waarde                               |
+      | type                          | ZoekMetNummeraanduidingIdentificatie |
+      | nummeraanduidingIdentificatie | 0599200000219679                     |
+      | fields                        | burgerservicenummer                  |
+      Dan heeft de response 0 personen
+
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "F" (fout) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "F"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0599                 | 0599200000219679                           |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | F                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                          | waarde                               |
+      | type                          | ZoekMetNummeraanduidingIdentificatie |
+      | nummeraanduidingIdentificatie | 0599200000219679                     |
+      | fields                        | burgerservicenummer                  |
+      Dan heeft de response 0 personen
+
+
+  Rule: Een persoonslijst met reden opschorting bijhouding ongelijk aan "O" (overleden) wordt alleen gevonden bij gebruik van parameter inclusiefOverledenPersonen met waarde true
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen wordt niet gebruikt
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0599                 | 0599200000219679                           |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                          | waarde                               |
+      | type                          | ZoekMetNummeraanduidingIdentificatie |
+      | nummeraanduidingIdentificatie | 0599200000219679                     |
+      | fields                        | burgerservicenummer                  |
+      Dan heeft de response 0 personen
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen heeft waarde <inclusiefOverledenPersonen>
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0599                 | 0599200000219679                           |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                          | waarde                               |
+      | type                          | ZoekMetNummeraanduidingIdentificatie |
+      | nummeraanduidingIdentificatie | 0599200000219679                     |
+      | fields                        | burgerservicenummer                  |
+      | inclusiefOverledenPersonen    | <inclusiefOverledenPersonen>         |
+      Dan heeft de response <aantal gevonden personen> persoon
+
+      Voorbeelden:
+      | inclusiefOverledenPersonen | aantal gevonden personen |
+      | false                      | 0                        |
+      | true                       | 1                        |
+
+
+  Rule: Een persoonslijst met overige reden opschorting bijhouding kan wel worden gevonden en geleverd
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "<opschorting>"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | identificatiecode nummeraanduiding (11.90) |
+      | 0599                 | 0599200000219679                           |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | <opschorting>                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                          | waarde                               |
+      | type                          | ZoekMetNummeraanduidingIdentificatie |
+      | nummeraanduidingIdentificatie | 0599200000219679                     |
+      | fields                        | burgerservicenummer                  |
+      Dan heeft de response 1 persoon
+
+      Voorbeelden:
+      | opschorting | omschrijving              |
+      | E           | emigratie                 |
+      | M           | ministerieel besluit      |
+      | R           | pl is aangelegd in de rni |
+      | .           | onbekend                  |

--- a/features/bevragen/zoek-met-postcode-en-huisnummer/dev/opschorting-bijhouding-gba.feature
+++ b/features/bevragen/zoek-met-postcode-en-huisnummer/dev/opschorting-bijhouding-gba.feature
@@ -1,0 +1,118 @@
+#language: nl
+
+@gba
+Functionaliteit: ZoekMetPostcodeEnHuisnummer van persoonslijst met opschorting bijhouding
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "W" (wissen) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "W"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeente_code | postcode (11.60) | huisnummer (11.20) |
+      | 0599          | 2628HJ           | 2                  |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | W                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam       | waarde                      |
+      | type       | ZoekMetPostcodeEnHuisnummer |
+      | postcode   | 2628HJ                      |
+      | huisnummer | 2                           |
+      | fields     | burgerservicenummer         |
+      Dan heeft de response 0 personen
+
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "F" (fout) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "F"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeente_code | postcode (11.60) | huisnummer (11.20) |
+      | 0599          | 2628HJ           | 2                  |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | F                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam       | waarde                      |
+      | type       | ZoekMetPostcodeEnHuisnummer |
+      | postcode   | 2628HJ                      |
+      | huisnummer | 2                           |
+      | fields     | burgerservicenummer         |
+      Dan heeft de response 0 personen
+
+
+  Rule: Een persoonslijst met reden opschorting bijhouding ongelijk aan "O" (overleden) wordt alleen gevonden bij gebruik van parameter inclusiefOverledenPersonen met waarde true
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen wordt niet gebruikt
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeente_code | postcode (11.60) | huisnummer (11.20) |
+      | 0599          | 2628HJ           | 2                  |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam       | waarde                      |
+      | type       | ZoekMetPostcodeEnHuisnummer |
+      | postcode   | 2628HJ                      |
+      | huisnummer | 2                           |
+      | fields     | burgerservicenummer         |
+      Dan heeft de response 0 personen
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen heeft waarde <inclusiefOverledenPersonen>
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeente_code | postcode (11.60) | huisnummer (11.20) |
+      | 0599          | 2628HJ           | 2                  |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                       |
+      | type                       | ZoekMetPostcodeEnHuisnummer  |
+      | postcode                   | 2628HJ                       |
+      | huisnummer                 | 2                            |
+      | fields                     | burgerservicenummer          |
+      | inclusiefOverledenPersonen | <inclusiefOverledenPersonen> |
+      Dan heeft de response <aantal gevonden personen> persoon
+
+      Voorbeelden:
+      | inclusiefOverledenPersonen | aantal gevonden personen |
+      | false                      | 0                        |
+      | true                       | 1                        |
+
+
+  Rule: Een persoonslijst met overige reden opschorting bijhouding kan wel worden gevonden en geleverd
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "<opschorting>"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeente_code | postcode (11.60) | huisnummer (11.20) |
+      | 0599          | 2628HJ           | 2                  |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | <opschorting>                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam       | waarde                      |
+      | type       | ZoekMetPostcodeEnHuisnummer |
+      | postcode   | 2628HJ                      |
+      | huisnummer | 2                           |
+      | fields     | burgerservicenummer         |
+      Dan heeft de response 1 persoon
+
+      Voorbeelden:
+      | opschorting | omschrijving              |
+      | E           | emigratie                 |
+      | M           | ministerieel besluit      |
+      | R           | pl is aangelegd in de rni |
+      | .           | onbekend                  |

--- a/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/opschorting-bijhouding-gba.feature
+++ b/features/bevragen/zoek-met-straatnaam-huisnummer-en-gemeente-van-inschrijving/dev/opschorting-bijhouding-gba.feature
@@ -1,0 +1,123 @@
+#language: nl
+
+@gba
+Functionaliteit: ZoekMetStraatHuisnummerEnGemeenteVanInschrijving van persoonslijst met opschorting bijhouding
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "W" (wissen) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "W"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) |
+      | 0599                 | Boterdiep          | 32                 |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | W                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                                           |
+      | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+      | straat                  | Boterdiep                                        |
+      | huisnummer              | 32                                               |
+      | gemeenteVanInschrijving | 0599                                             |
+      | fields                  | burgerservicenummer                              |
+      Dan heeft de response 0 personen
+
+
+  Rule: Een persoonslijst met reden opschorting bijhouding "F" (fout) wordt niet geleverd
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "F"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) |
+      | 0599                 | Boterdiep          | 32                 |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | F                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                                           |
+      | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+      | straat                  | Boterdiep                                        |
+      | huisnummer              | 32                                               |
+      | gemeenteVanInschrijving | 0599                                             |
+      | fields                  | burgerservicenummer                              |
+      Dan heeft de response 0 personen
+
+
+  Rule: Een persoonslijst met reden opschorting bijhouding ongelijk aan "O" (overleden) wordt alleen gevonden bij gebruik van parameter inclusiefOverledenPersonen met waarde true
+
+    Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen wordt niet gebruikt
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) |
+      | 0599                 | Boterdiep          | 32                 |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                                           |
+      | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+      | straat                  | Boterdiep                                        |
+      | huisnummer              | 32                                               |
+      | gemeenteVanInschrijving | 0599                                             |
+      | fields                  | burgerservicenummer                              |
+      Dan heeft de response 0 personen
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "O" en inclusiefOverledenPersonen heeft waarde <inclusiefOverledenPersonen>
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) |
+      | 0599                 | Boterdiep          | 32                 |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | O                                    |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                       | waarde                                           |
+      | type                       | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+      | straat                     | Boterdiep                                        |
+      | huisnummer                 | 32                                               |
+      | gemeenteVanInschrijving    | 0599                                             |
+      | fields                     | burgerservicenummer                              |
+      | inclusiefOverledenPersonen | <inclusiefOverledenPersonen>                     |
+      Dan heeft de response <aantal gevonden personen> persoon
+
+      Voorbeelden:
+      | inclusiefOverledenPersonen | aantal gevonden personen |
+      | false                      | 0                        |
+      | true                       | 1                        |
+
+
+  Rule: Een persoonslijst met overige reden opschorting bijhouding kan wel worden gevonden en geleverd
+
+    Abstract Scenario: persoonslijst heeft opschorting bijhouding reden "<opschorting>"
+      Gegeven de persoon met burgerservicenummer '000000024' heeft de volgende 'verblijfplaats' gegevens
+      | gemeente van inschrijving (09.10) |
+      | 0599                              |
+      En de 'verblijfplaats' heeft de volgende 'adres' gegevens
+      | gemeentecode (92.10) | straatnaam (11.10) | huisnummer (11.20) |
+      | 0599                 | Boterdiep          | 32                 |
+      En de persoon heeft de volgende 'inschrijving' gegevens
+      | datum opschorting bijhouding (67.10) | reden opschorting bijhouding (67.20) |
+      | 20220829                             | <opschorting>                        |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                    | waarde                                           |
+      | type                    | ZoekMetStraatHuisnummerEnGemeenteVanInschrijving |
+      | straat                  | Boterdiep                                        |
+      | huisnummer              | 32                                               |
+      | gemeenteVanInschrijving | 0599                                             |
+      | fields                  | burgerservicenummer                              |
+      Dan heeft de response 1 persoon
+
+      Voorbeelden:
+      | opschorting | omschrijving              |
+      | E           | emigratie                 |
+      | M           | ministerieel besluit      |
+      | R           | pl is aangelegd in de rni |
+      | .           | onbekend                  |


### PR DESCRIPTION
... zelfs wanneer de reden code niet bekend is

(bij een niet bekende code wordt op dit moment alleen de datum opschorting geleverd, burgerservicenummer en A-nummer, geen andere gegevens, en ook niet die code zelf)