### PR TITLE
Onjuiste partner zonder onjuist

### DIFF
--- a/features/bevragen/persoon/partner/aangaan-huwelijk-partnerschap/dev/aangaanHuwelijkPartnerschap-gba.feature
+++ b/features/bevragen/persoon/partner/aangaan-huwelijk-partnerschap/dev/aangaanHuwelijkPartnerschap-gba.feature
@@ -104,3 +104,32 @@ Functionaliteit: aangaan huwelijk/partnerschap bij actuele of ontbonden relatie
       | plaats.omschrijving | Brussel  |
       | land.code           | 5010     |
       | land.omschrijving   | België   |
+
+    Scenario: partnerschap is ontbonden en gegevens over het aangaan en ontbinden zijn gecorrigeerd
+      Gegeven de persoon met burgerservicenummer '000000012' heeft een 'partner' met de volgende gegevens
+      | naam                                                                | waarde    |
+      | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10)  | 20010801  |
+      | plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) | Parijs    |
+      | land huwelijkssluiting/aangaan geregistreerd partnerschap (06.30)   | 5002      |
+      En de 'partner' is gecorrigeerd naar de volgende gegevens
+      | naam                                                                | waarde    |
+      | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10)  | 20010902  |
+      | plaats huwelijkssluiting/aangaan geregistreerd partnerschap (06.20) | Brussel   |
+      | land huwelijkssluiting/aangaan geregistreerd partnerschap (06.30)   | 5010      |
+      En de 'partner' is gewijzigd naar de volgende gegevens
+      | naam                                                         | waarde   |
+      | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 20180103 |
+      En de 'partner' is gecorrigeerd naar de volgende gegevens
+      | naam                                                         | waarde   |
+      | datum ontbinding huwelijk/geregistreerd partnerschap (07.10) | 20180104 |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                               |
+      | type                | RaadpleegMetBurgerservicenummer      |
+      | burgerservicenummer | 000000012                            |
+      | fields              | partners.aangaanHuwelijkPartnerschap |
+      Dan heeft de response een persoon met een 'partner' met alleen de volgende 'aangaanHuwelijkPartnerschap' gegevens
+      | naam                | waarde   |
+      | datum               | 20010902 |
+      | plaats.omschrijving | Brussel  |
+      | land.code           | 5010     |
+      | land.omschrijving   | België   |

--- a/features/bevragen/persoon/partner/dev/overzicht-gba.feature
+++ b/features/bevragen/persoon/partner/dev/overzicht-gba.feature
@@ -170,6 +170,34 @@ Rule: Een partner wordt alleen teruggegeven als minimaal één gegeven in de ide
     | fields              | partners                        |
     Dan heeft de response een persoon zonder 'partner' gegevens
 
+  Scenario: huwelijk is onjuist - maar dit is niet als correctie doorgevoerd
+    Gegeven de persoon met burgerservicenummer '000000061' heeft een 'partner' met de volgende gegevens
+    | naam                                                               | waarde          |
+    | voornamen (02.10)                                                  | Daan            |
+    | voorvoegsel (02.30)                                                | de              |
+    | geslachtsnaam (02.40)                                              | Vries           |
+    | geboortedatum (03.10)                                              | 19830715        |
+    | soort verbintenis (15.10)                                          | H               |
+    | datum huwelijkssluiting/aangaan geregistreerd partnerschap (06.10) | 20031107        |
+    | gemeente document (82.10)                                          | 0518            |
+    | datum document (82.20)                                             | 20031109        |
+    | beschrijving document (82.30)                                      | PL gerelateerde |
+    | ingangsdatum geldigheid (85.10)                                    | 20031107        |
+    | datum van opneming (86.10)                                         | 20031109        |
+    En het 'partner' is gewijzigd naar de volgende gegevens
+    | naam                            | waarde           |
+    | gemeente document (82.10)       | 0518             |
+    | datum document (82.20)          | 20040105         |
+    | beschrijving document (82.30)   | D27894-2004-A782 |
+    | ingangsdatum geldigheid (85.10) | 20031107         |
+    | datum van opneming (86.10)      | 20040112         |
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 000000061                       |
+    | fields              | partners                        |
+    Dan heeft de response een persoon zonder 'partner' gegevens
+
 
 Rule: Wanneer er meerdere actuele (niet-ontbonden) huwelijken/partnerschappen zijn, worden die allemaal geleverd
 


### PR DESCRIPTION
- scenario dat test dat onjuist huwelijk ook als wijziging -geen correctie- kan worden geregistreerd (hoort eigenlijk niet, maar kan wel voorkomen)
- scenario dat gegevens over aangaan en ontbinding zijn gecorrigeerd