### PR TITLE
toevoegen scenario levenloos geboren kind

### DIFF
--- a/features/bevragen/persoon/kind/dev/kinderen-gba.feature
+++ b/features/bevragen/persoon/kind/dev/kinderen-gba.feature
@@ -165,3 +165,28 @@ Functionaliteit: kinderen raadplegen
       | naam                | waarde    |
       | burgerservicenummer | 000000097 |
       | naam.voornamen      | Karel     |
+
+  Rule: een levenloos geboren kind wordt niet geleverd.
+    Dit is het geval wanneer Registratie betrekking (89.10) een waarde heeft.
+
+    # Leveren van een levenloos geboren kind mag alleen wanneer de afnemer daarvoor geautoriseerd is (autorisatie rubriek 35.95.14).
+    # Op dit moment heeft de API nog geen veld waarin kan worden aangegeven dat een kind levenloos geboren is.
+    # Voorlopig zijn er geen afnemers voor de API die geautoriseerd zijn voor een levenloos kind.
+    # Tot er een afnemer is met autorisatie voor 35.95.14, die autorisatie is gebouwd en er een indicatie levenloos geboren is toegevoegd, mag een levenloos geboren kind niet worden geleverd. 
+    # Zie #855.
+    
+    Scenario: de persoon heeft een levenloos geboren kind en een levend kind
+      Gegeven de persoon met burgerservicenummer '000000073' heeft een 'kind' met de volgende gegevens
+      | voornamen (02.10) |
+      | Bert              |
+      En de persoon heeft nog een 'kind' met de volgende gegevens
+      | voornamen (02.10) | registratie betrekking (89.10) |
+      | Ernie             | L                              |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000073                       |
+      | fields              | kinderen.naam.voornamen         |
+      Dan heeft de response een persoon met een 'kind' met de volgende 'naam' gegevens
+      | naam      | waarde |
+      | voornamen | Bert   |

--- a/features/step_definitions/step_defs.js
+++ b/features/step_definitions/step_defs.js
@@ -246,6 +246,8 @@ const columnNameMap = new Map([
 
     ['rni-deelnemer (88.10)', 'rni_deelnemer'],
     ['omschrijving verdrag (88.20)', 'verdrag_oms'],
+
+    ['registratie betrekking (89.10)', 'registratie_betrekking'],
 	
     ['gemeentecode (92.10)', 'gemeente_code'],
     ['gemeente_code', 'gemeente_code'],


### PR DESCRIPTION
Dit was al lang geleden besloten, is blijkbaar ook al zo gebouwd (scenario slaagt), maar nog niet goed in feature gedocumenteerd. Bij deze. Zie #855, waarin de beslissing staat dit zo te doen.