### PR TITLE
aanvullingen scenario's zodat fields-mapping overbodig wordt

### DIFF
--- a/features/bevragen/persoon/kind/dev/kind-naam-gba.feature
+++ b/features/bevragen/persoon/kind/dev/kind-naam-gba.feature
@@ -23,3 +23,17 @@ Functionaliteit: kind - naam
       | kinderen.naam                                                                 |
       | kinderen.naam.voornamen,kinderen.naam.geslachtsnaam                           |
       | kinderen.naam.voornamen,kinderen.naam.voorvoegsel,kinderen.naam.geslachtsnaam |
+
+    Scenario: Kind voorletters gevraagd
+      Gegeven de persoon met burgerservicenummer '000000152' heeft een 'kind' met de volgende gegevens
+      | naam                  | waarde  |
+      | voornamen (02.10)     | William |
+      | geslachtsnaam (02.40) | Postma  |
+      Als gba personen wordt gezocht met de volgende parameters
+      | naam                | waarde                          |
+      | type                | RaadpleegMetBurgerservicenummer |
+      | burgerservicenummer | 000000152                       |
+      | fields              | kinderen.naam.voorletters       |
+      Dan heeft de response een persoon met een 'kind' met de volgende 'naam' gegevens
+      | naam          | waarde  |
+      | voornamen     | William |

--- a/features/bevragen/persoon/naam/dev/fields-gba.feature
+++ b/features/bevragen/persoon/naam/dev/fields-gba.feature
@@ -78,6 +78,10 @@ Rule: voornamen wordt geleverd bij field pad 'naam.voorletters'
     | naam                                 | waarde      |
     | geslachtsaanduiding (04.10)          | M           |
     | voornamen (02.10)                    | Hendrik Jan |
+    | adellijke titel of predicaat (02.20) | B           |
+    | voorvoegsel (02.30)                  | van den     |
+    | geslachtsnaam (02.40)                | Aedel       |
+    | aanduiding naamgebruik (61.10)       | E           |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |

--- a/features/bevragen/persoon/ouder/dev/ouders-gba.feature
+++ b/features/bevragen/persoon/ouder/dev/ouders-gba.feature
@@ -414,3 +414,25 @@ Rule: wanneer geboorteplaats (03.20) geen valide gemeentecode bevat, dan wordt d
     Dan heeft de response een persoon met een 'ouder' met de volgende 'geboorte' gegevens
     | naam                | waarde            |
     | plaats.omschrijving | 52°2'43N4°22'39"O |
+
+
+Rule: Wanneer gevraagd wordt om de voorletters van de ouders, worden de voornamen geleverd
+
+  Scenario: Gevraag wordt om de voorletters van de ouders
+    Gegeven de persoon met burgerservicenummer '000000152' heeft een ouder '1' met de volgende gegevens
+    | voornamen (02.10) | geslachtsnaam (02.40) |
+    | Lisette           | Postma                |
+    En de persoon heeft een ouder '2' met de volgende gegevens
+    | voornamen (02.10) | geslachtsnaam (02.40) |
+    | Guîllaumé         | Postma                |
+    Als gba personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 000000152                       |
+    | fields              | ouders.naam.voorletters         |
+    Dan heeft de response een persoon met een 'ouder' met de volgende gegevens
+    | naam            | waarde  |
+    | naam.voornamen  | Lisette |
+    En heeft de persoon een 'ouder' met de volgende gegevens
+    | naam            | waarde    |
+    | naam.voornamen  | Guîllaumé |

--- a/features/bevragen/persoon/partner/dev/fields-gba.feature
+++ b/features/bevragen/persoon/partner/dev/fields-gba.feature
@@ -159,8 +159,11 @@ Rule: voornamen wordt geleverd met field pad 'naam.voorletters'
 
   Scenario: 'voorletters' wordt gevraagd met field pad 'naam.voorletters'
     Gegeven de persoon met burgerservicenummer '000000176' heeft een 'partner' met de volgende gegevens
-    | naam              | waarde   |
-    | voornamen (02.10) | Carolina |
+    | naam                                 | waarde   |
+    | voornamen (02.10)                    | Carolina |
+    | adellijke titel of predicaat (02.20) | R        |
+    | voorvoegsel (02.30)                  | de       |
+    | geslachtsnaam (02.40)                | Groen    |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |

--- a/features/bevragen/persoon/verblijfplaats/dev/fields-gba.feature
+++ b/features/bevragen/persoon/verblijfplaats/dev/fields-gba.feature
@@ -206,27 +206,31 @@ Rule: wanneer één of meerdere velden van een adres wordt gevraagd met de field
     | verblijfplaatsBinnenland.verblijfadres                                              | huisnummer               | 31            |                   |               |                           |               |
     | verblijfplaatsBinnenland.datumVan,verblijfplaatsBinnenland.verblijfadres.huisnummer | datumAanvangAdreshouding | 20150808      | huisnummer        | 31            |                           |               |
 
-  Scenario: verblijfsadres van een adres wordt gevraagd en levert alle velden met een waarde
+  Abstract Scenario: <fields> wordt gevraagd en levert alle verblijfadres velden met een waarde
     Gegeven de persoon met burgerservicenummer '000000152' heeft de volgende 'verblijfplaats' gegevens
     | naam                               | waarde   |
     | datum aanvang adreshouding (10.30) | 20150808 |
     | functie adres (10.10)              | W        |
+    | datum ingang geldigheid (85.10)    | 20150808 |
+    | gemeente van inschrijving (09.10)  | 0519     |
     En de 'verblijfplaats' heeft de volgende 'adres' gegevens
-    | naam                              | waarde                    |
-    | gemeentecode (92.10)              | 0519                      |
-    | straatnaam (11.10)                | Spui                      |
-    | naam openbare ruimte (11.15)      | Burgemeester aan het Spui |
-    | huisnummer (11.20)                | 70                        |
-    | huisletter (11.30)                | A                         |
-    | huisnummertoevoeging (11.40)      | 2                         |
-    | aanduiding bij huisnummer (11.50) | to                        |
-    | postcode (11.60)                  | 1234AB                    |
-    | woonplaats (11.70)                | Den Haag                  |
+    | naam                                       | waarde                    |
+    | gemeentecode (92.10)                       | 0519                      |
+    | straatnaam (11.10)                         | Spui                      |
+    | naam openbare ruimte (11.15)               | Burgemeester aan het Spui |
+    | huisnummer (11.20)                         | 70                        |
+    | huisletter (11.30)                         | A                         |
+    | huisnummertoevoeging (11.40)               | 2                         |
+    | aanduiding bij huisnummer (11.50)          | to                        |
+    | postcode (11.60)                           | 1234AB                    |
+    | woonplaats (11.70)                         | Den Haag                  |
+    | identificatiecode verblijfplaats (11.80)   | 0519020000012345          |
+    | identificatiecode nummeraanduiding (11.90) | 0519200000012345          |
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
     | burgerservicenummer | 000000152                       |
-    | fields              | verblijfplaatsBinnenland.verblijfadres                        |
+    | fields              | <fields>                        |
     Dan heeft de response een persoon met de volgende 'verblijfplaats' gegevens
     | naam                                 | waarde                    |
     | straat                               | Spui                      |
@@ -238,6 +242,11 @@ Rule: wanneer één of meerdere velden van een adres wordt gevraagd met de field
     | aanduidingBijHuisnummer.omschrijving | tegenover                 |
     | postcode                             | 1234AB                    |
     | woonplaats                           | Den Haag                  |
+
+    Voorbeelden:
+    | fields                                 |
+    | verblijfplaats.verblijfadres           |
+    | verblijfplaatsBinnenland.verblijfadres |
 
 Rule: wanneer één of meerdere velden van een locatie wordt gevraagd met de field alias verblijfplaatsBinnenland, dan wordt ook de waarde van 'locatiebeschrijving (12.10)' geleverd
 


### PR DESCRIPTION
check gedaan op de velden die in [features/gba-dev/fields-mapping-gba.csv](https://github.com/BRP-API/Haal-Centraal-BRP-bevragen/blob/develop/features/gba-dev/fields-mapping-gba.csv) staan. Scenario's toegevoegd of uitgebreid zodat al deze velden ergens getoond en getest worden. Daarmee wordt de fields-mapping-gba "overbodig" en kan verwijderd worden. 