### PR TITLE
Correctie header scenarios

### DIFF
--- a/features/bevragen/zoek-fout-cases-gba.feature
+++ b/features/bevragen/zoek-fout-cases-gba.feature
@@ -183,12 +183,11 @@ Rule: als contenttype voor het request wordt alleen application/json en charset 
 
 Rule: contenttype voor de response is default application/json en charset utf-8
 
-  @fout-case
   Scenario: Lege Accept contenttype wordt ondersteund
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer | 999999321                       |
+    | burgerservicenummer | 000000024                       |
     | fields              | burgerservicenummer             |
     | header: Accept      |                                 |
     Dan heeft de response 0 personen
@@ -196,12 +195,11 @@ Rule: contenttype voor de response is default application/json en charset utf-8
 
 Rule: contenttype voor het request is default application/json en charset utf-8
 
-  @fout-case
   Scenario: Lege Content-Type wordt ondersteund
     Als gba personen wordt gezocht met de volgende parameters
     | naam                 | waarde                          |
     | type                 | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer  | 999999321                       |
+    | burgerservicenummer  | 000000024                       |
     | fields               | burgerservicenummer             |
     | header: Content-Type |                                 |
     Dan heeft de response 0 personen

--- a/features/bevragen/zoek-fout-cases-gba.feature
+++ b/features/bevragen/zoek-fout-cases-gba.feature
@@ -85,17 +85,17 @@ Rule: als contenttype voor de response wordt alleen application/json en charset 
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer | 999999321                       |
+    | burgerservicenummer | 000000024                       |
     | fields              | burgerservicenummer             |
     | header: Accept      | application/xml                 |
     Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                 |
-    | title    | Gevraagde contenttype wordt niet ondersteund.                               |
-    | detail   | Ondersteunde content type: */*, application/json. Default: application/json |
-    | code     | notAcceptable                                                               |
-    | status   | 406                                                                         |
-    | instance | /haalcentraal/api/brp/personen                                              |
+    | naam     | waarde                                                                                                                                                                              |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                                                                                                                         |
+    | title    | Gevraagde contenttype wordt niet ondersteund.                                                                                                                                       |
+    | detail   | Ondersteunde content type: */*, */*;charset=utf-8, */*; charset=utf-8, application/json, application/json; charset=utf-8, application/json;charset=utf-8. Default: application/json |
+    | code     | notAcceptable                                                                                                                                                                       |
+    | status   | 406                                                                                                                                                                                 |
+    | instance | /haalcentraal/api/brp/personen                                                                                                                                                      |
 
   Abstract Scenario: '<accept media type>' als Accept contenttype wordt ondersteund
     Als gba personen wordt gezocht met de volgende parameters
@@ -166,13 +166,13 @@ Rule: als contenttype voor het request wordt alleen application/json en charset 
     | fields               | burgerservicenummer             |
     | header: Content-Type | <media type>                    |
     Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                                                                                                       |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13                                                                                                 |
-    | title    | Media Type wordt niet ondersteund.                                                                                                                           |
-    | detail   | Ondersteunde content type: */*, application/json, application/json; charset=utf-8, application/json;charset=utf-8. Default: application/json; charset=utf-8. |
-    | code     | unsupportedMediaType                                                                                                                                         |
-    | status   | 415                                                                                                                                                          |
-    | instance | /haalcentraal/api/brp/personen                                                                                                                               |
+    | naam     | waarde                                                                                                                                                                                              |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13                                                                                                                                        |
+    | title    | Media Type wordt niet ondersteund.                                                                                                                                                                  |
+    | detail   | Ondersteunde content type: */*, */*;charset=utf-8, */*; charset=utf-8, application/json, application/json; charset=utf-8, application/json;charset=utf-8. Default: application/json; charset=utf-8. |
+    | code     | unsupportedMediaType                                                                                                                                                                                |
+    | status   | 415                                                                                                                                                                                                 |
+    | instance | /haalcentraal/api/brp/personen                                                                                                                                                                      |
 
     Voorbeelden:
     | media type                       |

--- a/features/bevragen/zoek-fout-cases.feature
+++ b/features/bevragen/zoek-fout-cases.feature
@@ -199,12 +199,11 @@ Rule: als contenttype voor het request wordt alleen application/json en charset 
 
 Rule: contenttype voor de response is default application/json en charset utf-8
 
-  @fout-case
   Scenario: Lege Accept contenttype wordt ondersteund
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer | 999999321                       |
+    | burgerservicenummer | 000000024                       |
     | fields              | burgerservicenummer             |
     | header: Accept      |                                 |
     Dan heeft de response 0 personen
@@ -212,12 +211,11 @@ Rule: contenttype voor de response is default application/json en charset utf-8
 
 Rule: contenttype voor het request is default application/json en charset utf-8
 
-  @fout-case
   Scenario: Lege Content-Type wordt ondersteund
     Als personen wordt gezocht met de volgende parameters
     | naam                 | waarde                          |
     | type                 | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer  | 999999321                       |
+    | burgerservicenummer  | 000000024                       |
     | fields               | burgerservicenummer             |
     | header: Content-Type |                                 |
     Dan heeft de response 0 personen

--- a/features/bevragen/zoek-fout-cases.feature
+++ b/features/bevragen/zoek-fout-cases.feature
@@ -88,13 +88,13 @@ Rule: als contenttype voor de response wordt alleen application/json en charset 
     | fields              | burgerservicenummer             |
     | header: Accept      | application/xml                 |
     Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                 |
-    | title    | Gevraagde contenttype wordt niet ondersteund.                               |
-    | detail   | Ondersteunde content type: */*, application/json. Default: application/json |
-    | code     | notAcceptable                                                               |
-    | status   | 406                                                                         |
-    | instance | /haalcentraal/api/brp/personen                                              |
+    | naam     | waarde                                                                                                                                                                              |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                                                                                                                         |
+    | title    | Gevraagde contenttype wordt niet ondersteund.                                                                                                                                       |
+    | detail   | Ondersteunde content type: */*, */*;charset=utf-8, */*; charset=utf-8, application/json, application/json; charset=utf-8, application/json;charset=utf-8. Default: application/json |
+    | code     | notAcceptable                                                                                                                                                                       |
+    | status   | 406                                                                                                                                                                                 |
+    | instance | /haalcentraal/api/brp/personen                                                                                                                                                      |
 
   @fout-case
   Scenario: Lege Accept contenttype wordt niet ondersteund
@@ -105,13 +105,13 @@ Rule: als contenttype voor de response wordt alleen application/json en charset 
     | fields              | burgerservicenummer             |
     | header: Accept      |                                 |
     Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                 |
-    | title    | Gevraagde contenttype wordt niet ondersteund.                               |
-    | detail   | Ondersteunde content type: */*, application/json. Default: application/json |
-    | code     | notAcceptable                                                               |
-    | status   | 406                                                                         |
-    | instance | /haalcentraal/api/brp/personen                                              |
+    | naam     | waarde                                                                                                                                                                              |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                                                                                                                         |
+    | title    | Gevraagde contenttype wordt niet ondersteund.                                                                                                                                       |
+    | detail   | Ondersteunde content type: */*, */*;charset=utf-8, */*; charset=utf-8, application/json, application/json; charset=utf-8, application/json;charset=utf-8. Default: application/json |
+    | code     | notAcceptable                                                                                                                                                                       |
+    | status   | 406                                                                                                                                                                                 |
+    | instance | /haalcentraal/api/brp/personen                                                                                                                                                      |
 
   Abstract Scenario: '<accept media type>' als Accept contenttype wordt ondersteund
     Als personen wordt gezocht met de volgende parameters
@@ -182,13 +182,13 @@ Rule: als contenttype voor het request wordt alleen application/json en charset 
     | fields               | burgerservicenummer             |
     | header: Content-Type | <media type>                    |
     Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                                                                                                       |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13                                                                                                 |
-    | title    | Media Type wordt niet ondersteund.                                                                                                                           |
-    | detail   | Ondersteunde content type: */*, application/json, application/json; charset=utf-8, application/json;charset=utf-8. Default: application/json; charset=utf-8. |
-    | code     | unsupportedMediaType                                                                                                                                         |
-    | status   | 415                                                                                                                                                          |
-    | instance | /haalcentraal/api/brp/personen                                                                                                                               |
+    | naam     | waarde                                                                                                                                                                                              |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13                                                                                                                                        |
+    | title    | Media Type wordt niet ondersteund.                                                                                                                                                                  |
+    | detail   | Ondersteunde content type: */*, */*;charset=utf-8, */*; charset=utf-8, application/json, application/json; charset=utf-8, application/json;charset=utf-8. Default: application/json; charset=utf-8. |
+    | code     | unsupportedMediaType                                                                                                                                                                                |
+    | status   | 415                                                                                                                                                                                                 |
+    | instance | /haalcentraal/api/brp/personen                                                                                                                                                                      |
 
     Voorbeelden:
     | media type                       |


### PR DESCRIPTION
- correctie scenario's voor content-type en accept headers: zijn geen @foutcase en moeten 0 personen vinden
- gelijktrekken foutmelding detail voor 406/415 op implementatie gba API
n.a.v. #1598 "Fouten rondom accept en contenttype in scenarios"