### PR TITLE
fix(specs): accept en content-type scenario's

### DIFF
--- a/features/bevragen/zoek-fout-cases-gba.feature
+++ b/features/bevragen/zoek-fout-cases-gba.feature
@@ -89,13 +89,13 @@ Rule: als contenttype voor de response wordt alleen application/json en charset 
     | fields              | burgerservicenummer             |
     | header: Accept      | application/xml                 |
     Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                 |
-    | title    | Gevraagde contenttype wordt niet ondersteund.                               |
-    | detail   | Ondersteunde content type: */*, application/json. Default: application/json |
-    | code     | notAcceptable                                                               |
-    | status   | 406                                                                         |
-    | instance | /haalcentraal/api/brp/personen                                              |
+    | naam     | waarde                                                                                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                                                                 |
+    | title    | Gevraagde contenttype wordt niet ondersteund.                                                                               |
+    | detail   | Ondersteunde content type: */*, application/json, application/json; charset=utf-8. Default: application/json; charset=utf-8 |
+    | code     | notAcceptable                                                                                                               |
+    | status   | 406                                                                                                                         |
+    | instance | /haalcentraal/api/brp/personen                                                                                              |
 
   Abstract Scenario: '<accept media type>' als Accept contenttype wordt ondersteund
     Als gba personen wordt gezocht met de volgende parameters
@@ -166,13 +166,13 @@ Rule: als contenttype voor het request wordt alleen application/json en charset 
     | fields               | burgerservicenummer             |
     | header: Content-Type | <media type>                    |
     Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                                                                                                       |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13                                                                                                 |
-    | title    | Media Type wordt niet ondersteund.                                                                                                                           |
-    | detail   | Ondersteunde content type: */*, application/json, application/json; charset=utf-8, application/json;charset=utf-8. Default: application/json; charset=utf-8. |
-    | code     | unsupportedMediaType                                                                                                                                         |
-    | status   | 415                                                                                                                                                          |
-    | instance | /haalcentraal/api/brp/personen                                                                                                                               |
+    | naam     | waarde                                                                                                                  |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13                                                            |
+    | title    | Media Type wordt niet ondersteund.                                                                                      |
+    | detail   | Ondersteunde content type: application/json, application/json; charset=utf-8. Default: application/json; charset=utf-8. |
+    | code     | unsupportedMediaType                                                                                                    |
+    | status   | 415                                                                                                                     |
+    | instance | /haalcentraal/api/brp/personen                                                                                          |
 
     Voorbeelden:
     | media type                       |
@@ -183,12 +183,11 @@ Rule: als contenttype voor het request wordt alleen application/json en charset 
 
 Rule: contenttype voor de response is default application/json en charset utf-8
 
-  @fout-case
   Scenario: Lege Accept contenttype wordt ondersteund
     Als gba personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer | 999999321                       |
+    | burgerservicenummer | 000000024                       |
     | fields              | burgerservicenummer             |
     | header: Accept      |                                 |
     Dan heeft de response 0 personen
@@ -196,12 +195,11 @@ Rule: contenttype voor de response is default application/json en charset utf-8
 
 Rule: contenttype voor het request is default application/json en charset utf-8
 
-  @fout-case
   Scenario: Lege Content-Type wordt ondersteund
     Als gba personen wordt gezocht met de volgende parameters
     | naam                 | waarde                          |
     | type                 | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer  | 999999321                       |
+    | burgerservicenummer  | 000000024                       |
     | fields               | burgerservicenummer             |
     | header: Content-Type |                                 |
     Dan heeft de response 0 personen

--- a/features/bevragen/zoek-fout-cases.feature
+++ b/features/bevragen/zoek-fout-cases.feature
@@ -88,30 +88,13 @@ Rule: als contenttype voor de response wordt alleen application/json en charset 
     | fields              | burgerservicenummer             |
     | header: Accept      | application/xml                 |
     Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                 |
-    | title    | Gevraagde contenttype wordt niet ondersteund.                               |
-    | detail   | Ondersteunde content type: */*, application/json. Default: application/json |
-    | code     | notAcceptable                                                               |
-    | status   | 406                                                                         |
-    | instance | /haalcentraal/api/brp/personen                                              |
-
-  @fout-case
-  Scenario: Lege Accept contenttype wordt niet ondersteund
-    Als personen wordt gezocht met de volgende parameters
-    | naam                | waarde                          |
-    | type                | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer | 999999321                       |
-    | fields              | burgerservicenummer             |
-    | header: Accept      |                                 |
-    Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                      |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                 |
-    | title    | Gevraagde contenttype wordt niet ondersteund.                               |
-    | detail   | Ondersteunde content type: */*, application/json. Default: application/json |
-    | code     | notAcceptable                                                               |
-    | status   | 406                                                                         |
-    | instance | /haalcentraal/api/brp/personen                                              |
+    | naam     | waarde                                                                                                                      |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.6                                                                 |
+    | title    | Gevraagde contenttype wordt niet ondersteund.                                                                               |
+    | detail   | Ondersteunde content type: */*, application/json, application/json; charset=utf-8. Default: application/json; charset=utf-8 |
+    | code     | notAcceptable                                                                                                               |
+    | status   | 406                                                                                                                         |
+    | instance | /haalcentraal/api/brp/personen                                                                                              |
 
   Abstract Scenario: '<accept media type>' als Accept contenttype wordt ondersteund
     Als personen wordt gezocht met de volgende parameters
@@ -182,13 +165,13 @@ Rule: als contenttype voor het request wordt alleen application/json en charset 
     | fields               | burgerservicenummer             |
     | header: Content-Type | <media type>                    |
     Dan heeft de response een object met de volgende gegevens
-    | naam     | waarde                                                                                                                                                       |
-    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13                                                                                                 |
-    | title    | Media Type wordt niet ondersteund.                                                                                                                           |
-    | detail   | Ondersteunde content type: */*, application/json, application/json; charset=utf-8, application/json;charset=utf-8. Default: application/json; charset=utf-8. |
-    | code     | unsupportedMediaType                                                                                                                                         |
-    | status   | 415                                                                                                                                                          |
-    | instance | /haalcentraal/api/brp/personen                                                                                                                               |
+    | naam     | waarde                                                                                                                  |
+    | type     | https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13                                                            |
+    | title    | Media Type wordt niet ondersteund.                                                                                      |
+    | detail   | Ondersteunde content type: application/json, application/json; charset=utf-8. Default: application/json; charset=utf-8. |
+    | code     | unsupportedMediaType                                                                                                    |
+    | status   | 415                                                                                                                     |
+    | instance | /haalcentraal/api/brp/personen                                                                                          |
 
     Voorbeelden:
     | media type                       |
@@ -199,12 +182,11 @@ Rule: als contenttype voor het request wordt alleen application/json en charset 
 
 Rule: contenttype voor de response is default application/json en charset utf-8
 
-  @fout-case
   Scenario: Lege Accept contenttype wordt ondersteund
     Als personen wordt gezocht met de volgende parameters
     | naam                | waarde                          |
     | type                | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer | 999999321                       |
+    | burgerservicenummer | 000000024                       |
     | fields              | burgerservicenummer             |
     | header: Accept      |                                 |
     Dan heeft de response 0 personen
@@ -212,12 +194,11 @@ Rule: contenttype voor de response is default application/json en charset utf-8
 
 Rule: contenttype voor het request is default application/json en charset utf-8
 
-  @fout-case
   Scenario: Lege Content-Type wordt ondersteund
     Als personen wordt gezocht met de volgende parameters
     | naam                 | waarde                          |
     | type                 | RaadpleegMetBurgerservicenummer |
-    | burgerservicenummer  | 999999321                       |
+    | burgerservicenummer  | 000000024                       |
     | fields               | burgerservicenummer             |
     | header: Content-Type |                                 |
     Dan heeft de response 0 personen


### PR DESCRIPTION
de volgende correcties zijn gemaakt:
- bij accept is 'application/json; charset=utf-8' toegevoegd
- bij content-type is '*/*' verwijderd
- bij content-type is 'application/json;chartset=utf-8' verwijderd. Is naar mijn mening hetzelfde als 'application/json; chartset=utf-8'
- fout-case tag weggehaald bij twee scenario's die geen fout scenario's zijn. Ook is de bsn in die scenario's aangepast zodat er geen persoon wordt gevonden