### PR TITLE
Adressering verblijfplaats fields

### DIFF
--- a/features/bevragen/persoon/adressering/adres-regels/fields-alias.feature
+++ b/features/bevragen/persoon/adressering/adres-regels/fields-alias.feature
@@ -33,6 +33,27 @@ Rule: de standaard adresregel veld paden kunnen worden gebruikt door een consume
     | adressering                                                                              | de adressering gegevensgroep veld           |
     | adressering.adresregel1,adressering.adresregel2,adressering.adresregel3,adressering.land | alle adresregel velden met hun volledig pad |
 
+  Scenario: afnemer vraagt adresseringBinnenland én verblijfplaats en de persoon heeft buitenlandse verblijfplaats
+    Gegeven de persoon met burgerservicenummer '000000097' heeft de volgende 'verblijfplaats' gegevens
+    | naam                             | waarde                      |
+    | land adres buitenland (13.10)    | 6014                        |
+    | regel 1 adres buitenland (13.30) | 1600 Pennsylvania Avenue NW |
+    | regel 2 adres buitenland (13.40) | Washington, DC 20500        |
+    | regel 3 adres buitenland (13.50) | Selangor                    |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                             |
+    | type                | RaadpleegMetBurgerservicenummer                    |
+    | burgerservicenummer | 000000097                                          |
+    | fields              | adresseringBinnenland,verblijfplaats.verblijfadres |
+    Dan heeft de response een persoon met de volgende 'verblijfplaats' gegevens
+    | naam                            | waarde                       |
+    | type                            | VerblijfplaatsBuitenland     |
+    | verblijfadres.regel1            | 1600 Pennsylvania Avenue NW  |
+    | verblijfadres.regel2            | Washington, DC 20500         |
+    | verblijfadres.regel3            | Selangor                     |
+    | verblijfadres.land.code         | 6014                         |
+    | verblijfadres.land.omschrijving | Verenigde Staten van Amerika |
+
   Abstract Scenario: afnemer is geautoriseerd voor 'adressering buitenland' en vraagt het <field> veld van de adressering gegevensgroep
     Gegeven de afnemer met indicatie '000008' is geautoriseerd voor 'adressering' gegevens
     En de persoon met burgerservicenummer '000000097' heeft de volgende 'verblijfplaats' gegevens

--- a/features/bevragen/persoon/verblijfplaats/fields-alias.feature
+++ b/features/bevragen/persoon/verblijfplaats/fields-alias.feature
@@ -124,3 +124,24 @@ Rule: de 'verblijfplaatsBinnenland' field alias moet worden gebruikt door een co
     | fields                                 | omschrijving              |
     | verblijfplaatsBinnenland               | alle velden               |
     | verblijfplaatsBinnenland.verblijfadres | alle verblijfadres velden |
+  
+  Scenario: afnemer vraagt verblijfplaatsBinnenland én adressering en de persoon heeft buitenlandse verblijfplaats
+    Gegeven de persoon met burgerservicenummer '000000097' heeft de volgende 'verblijfplaats' gegevens
+    | naam                             | waarde                      |
+    | land adres buitenland (13.10)    | 6014                        |
+    | regel 1 adres buitenland (13.30) | 1600 Pennsylvania Avenue NW |
+    | regel 2 adres buitenland (13.40) | Washington, DC 20500        |
+    | regel 3 adres buitenland (13.50) | Selangor                    |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                                             |
+    | type                | RaadpleegMetBurgerservicenummer                    |
+    | burgerservicenummer | 000000097                                          |
+    | fields              | adressering,verblijfplaatsBinnenland.verblijfadres |
+    Dan heeft de response een persoon met de volgende 'adressering' gegevens
+    | naam              | waarde                       |
+    | type              | VerblijfplaatsBuitenland     |
+    | adresregel1       | 1600 Pennsylvania Avenue NW  |
+    | adresregel2       | Washington, DC 20500         |
+    | adresregel3       | Selangor                     |
+    | land.code         | 6014                         |
+    | land.omschrijving | Verenigde Staten van Amerika |


### PR DESCRIPTION
toevoegen tests voor fields combinatie adresseringBinnenland met verblijfplaats, of verblijfplaatsBinnenland met adressering.

Op dit moment levert de API in dat geval ook een buitenlands adres op resp. adresseringBinnenland en verblijfplaatsBinnenland