### PR TITLE
extra scenario leveren inOnderzoek.type wanneer alleen nationaliteit wordt gevraagd

### DIFF
--- a/features/bevragen/persoon/nationaliteit/nationaliteit/in-onderzoek.feature
+++ b/features/bevragen/persoon/nationaliteit/nationaliteit/in-onderzoek.feature
@@ -35,3 +35,27 @@ Functionaliteit: Persoon: nationaliteit velden in onderzoek
     | 040510                  | true             |                 | true    | nationaliteit                    |
     | 046300                  |                  | true            |         | hele groep opnemen nationaliteit |
     | 046310                  |                  | true            |         | reden opname nationaliteit       |
+
+
+Scenario: 'hele categorie nationaliteit' is in onderzoek en alleen veld nationaliteit wordt gevraagd
+    Gegeven de persoon met burgerservicenummer '000000012' heeft een 'nationaliteit' met de volgende gegevens
+    | naam                            | waarde   |
+    | nationaliteit (05.10)           | 0001     |
+    | reden opname (63.10)            | 001      |
+    | aanduiding in onderzoek (83.10) | 040000   |
+    | datum ingang onderzoek (83.20)  | 20020701 |
+    Als personen wordt gezocht met de volgende parameters
+    | naam                | waarde                          |
+    | type                | RaadpleegMetBurgerservicenummer |
+    | burgerservicenummer | 000000012                       |
+    | fields              | nationaliteiten.nationaliteit   |
+    Dan heeft de response een persoon met een 'nationaliteit' met alleen de volgende gegevens
+    | naam                                         | waarde        |
+    | type                                         | Nationaliteit |
+    | nationaliteit.code                           | 0001          |
+    | nationaliteit.omschrijving                   | Nederlandse   |
+    | inOnderzoek.type                             | true          |
+    | inOnderzoek.nationaliteit                    | true          |
+    | inOnderzoek.datumIngangOnderzoek.type        | Datum         |
+    | inOnderzoek.datumIngangOnderzoek.datum       | 2002-07-01    |
+    | inOnderzoek.datumIngangOnderzoek.langFormaat | 1 juli 2002   |


### PR DESCRIPTION
is nu m.i. niet correct geïmplementeerd. in dit geval wordt nu alleen inOnderzoek van nationaliteit gemeld, terwijl type automatisch wordt meegeleverd is en ook in onderzoek staat.
scenario toont dat bij alleen vragen van nationaliteit ook het automatisch meegeleverde veld type in onderzoek kan zijn

deze situatie komt heel veel voor omdat heel veel afnemers alleen geautoriseerd zijn voor nationaliteit en niet voor redenOpname of datum ingang. zij zullen dus altijd fields=nationaliteiten.nationaliteit gebruiken