### PR TITLE
Update getting-started release experimentbesluit.md

### DIFF
--- a/docs/v2/getting-started.md
+++ b/docs/v2/getting-started.md
@@ -7,12 +7,12 @@ title: Getting Started
 Alle gemeenten en andere organisaties met een autorisatiebesluit conform artikel 38 van het Besluit BRP kunnen zich aanmelden voor deelname aan de pilot BRP.
 
 1. Bekijk de [functionaliteit en specificaties](#functionaliteit-en-specificaties)
-2. Probeer en test de API [lokaal](#probeer-en-test-de-api-lokaal) of in de [proef omgeving](#probeer-en-test-de-api-in-de-proef-omgeving)
+2. Probeer en test de BRP API [lokaal](#probeer-en-test-de-api-lokaal) of in de [proef omgeving](#probeer-en-test-de-api-in-de-proef-omgeving)
 3. [Download]({{ site.onboardingUrl }}){:target="_blank" rel="noopener"} en lees het onboardingproces
 
 ## Functionaliteit en specificaties
 
-De '{{ site.apiname }}' Web API is gespecificeerd met behulp van de [OpenAPI Specification v3.0.3](https://spec.openapis.org/oas/v3.0.3).
+De '{{ site.apiname }}' BRP API Personen is gespecificeerd met behulp van de [OpenAPI Specification v3.0.3](https://spec.openapis.org/oas/v3.0.3).
 
 De OAS3 specificatie van de '{{ site.apiname }}' Web API kan worden bekeken met behulp van [Redoc](./redoc).
 
@@ -22,24 +22,20 @@ De [funtionele documentatie](./features-overzicht) van de '{{ site.apiname }}' W
 
 ## Probeer en test de API in de proef omgeving
 
-De '{{ site.apiname }}' Web API kan worden geprobeerd via de proef omgeving met de volgende url: [{{ site.proefProxyUrl }}]. Hiervoor heb je een apikey nodig.
+De '{{ site.apiname }}' BRP API Personen kan worden geprobeerd via de proef omgeving met de volgende url: [{{ site.proefProxyUrl }}]. Hiervoor heb je een apikey nodig.
 
 - Vraag een apikey aan bij de product owner [{{ site.PO-email }}](mailto:{{ site.PO-email }}). De apikey die is uitgereikt op de API Labs kan ook worden gebruikt.
 - Voeg de apikey toe aan een request met de __X-API-KEY__ header.
 
 ## Probeer en test de API lokaal
 
-Door wettelijke restricties kan de '{{ site.apiname }}' Web API bepaalde bewerkingen niet uitvoeren. Er wordt op dit moment aan gewerkt om deze restricties weg te halen. Totdat dit is gerealiseerd moet de BrpProxy worden gebruikt om de bewerkte gegevens te kunnen krijgen. De BrpProxy is consumer van de GBA variant van de '{{ site.apiname }}' Web API en levert responses conform de {{ site.apiname }} [OAS3 specificatie]({{ site.devBranchUrl }}/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"}.
+De BRP API Personen is geïmplementeerd als een containerized applicatie, zodat het makkelijk kan worden getest op een lokale machine en worden gehost in een productie omgeving.
 
-De BrpProxy is geïmplementeerd als een containerized applicatie, zodat het makkelijk kan worden getest op een lokale machine en worden gehost in een productie omgeving.
+Het [docker compose bestand]({{ site.devBranchUrl }}/docker-compose.yml){:target="_blank" rel="noopener"} kan worden gebruikt om de BRP API Personen met behulp van [Docker Desktop](https://www.docker.com/products/docker-desktop) te draaien op een lokale machine.
 
-Het [docker compose bestand]({{ site.devBranchUrl }}/docker-compose.yml){:target="_blank" rel="noopener"} kan worden gebruikt om met behulp van [Docker Desktop](https://www.docker.com/products/docker-desktop) de BrpProxy en de mock van de '{{ site.apiname }}' Web API GBA variant te draaien op een lokale machine.
+In plaats van het docker compose bestand kunnen de [Kubernetes configuratie bestanden]({{ site.devBranchUrl}}/.k8s){:target="_blank" rel="noopener"} worden gebruikt om de API te draaien op een lokale machine. De API maakt gebruik van een mock met [testdataset persoonslijsten proefomgevingen GBA-V](https://www.rvig.nl/media/288) als input om de productie situatie zoveel mogelijk te kunnen simuleren.
 
-In plaats van het docker compose bestand kunnen de [Kubernetes configuratie bestanden]({{ site.devBranchUrl}}/.k8s){:target="_blank" rel="noopener"} worden gebruikt om de BrpProxy en de mock van de '{{ site.apiname }}' Web API GBA variant te draaien op een lokale machine.
-
-De mock van de '{{ site.apiname }}' Web API GBA variant is bedoeld voor development/test doeleinden. Deze mock gebruikt de [testdataset persoonslijsten proefomgevingen GBA-V](https://www.rvig.nl/media/288) als input om de productie situatie zoveel mogelijk te kunnen simuleren.
-
-De volgende paragrafen beschrijven het installeren en aanroepen van de BrpProxy op een lokale machine.
+De volgende paragrafen beschrijven het installeren en aanroepen van de BRP API Personen op een lokale machine.
 
 ### Prerequisites
 
@@ -49,21 +45,21 @@ De volgende paragrafen beschrijven het installeren en aanroepen van de BrpProxy 
 Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
 
 - [git](https://git-scm.com/downloads) voor het clonen van git repositories
-- [Postman](https://www.postman.com/downloads/) voor het aanroepen van Web APIs
+- [Postman](https://www.postman.com/downloads/) voor het aanroepen van Web API
 
 
 ### Gebruik Docker als container engine
 
 - Download het [docker compose bestand]({{ site.devBranchUrl }}/docker-compose.yml){:target="_blank" rel="noopener"}
 - Start een command prompt window voor de map met het docker-compose.yaml bestand
-- Start de BrpProxy en de mock met behulp van de volgende statement:
+- Start de BRP API Personen en de mock met behulp van de volgende statement:
   ```sh
 
   docker-compose up -d
 
   ```
-  De BrpProxy is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
-- Valideer dat de BrpProxy en de mock draaien met behulp van de volgende curl statement:
+  De BRP API Personen is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
+- Valideer dat de BRP API Personen en de mock draaien met behulp van de volgende curl statement:
   ```sh
 
   curl --location --request POST 'http://localhost:5001/haalcentraal/api/brp/personen' \
@@ -75,7 +71,7 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
   }'
 
   ```
-- Om de BrpProxy en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
+- Om de BRP API Personen en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
   ```sh
 
   docker-compose down
@@ -86,7 +82,7 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
 
 - Download de [kubernetes configuratie bestanden]({{ site.devBranchUrl }}/.k8s){:target="_blank" rel="noopener"}
 - Start een command prompt window voor de map met de kubernetes manifest bestanden
-- Start de BrpProxy en de mock met behulp van de volgende statement:
+- Start de BRP API Personen en de mock met behulp van de volgende statement:
   ```sh
 
   kubectl apply -f .k8s/brpproxy-deployment.yaml \
@@ -95,8 +91,8 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
                 -f .k8s/gbamock-service.yaml 
 
   ```
-  De BrpProxy is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
-- Valideer dat de BrpProxy en de mock draaien met behulp van de volgende curl statement:
+  De BRP API Personen is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
+- Valideer dat de BRP API Personen en de mock draaien met behulp van de volgende curl statement:
   ```sh
 
   curl --location --request POST 'http://localhost:5001/haalcentraal/api/brp/personen' \
@@ -108,7 +104,7 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
   }'
 
   ```
-- Om de BrpProxy en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
+- Om de BRP API Personen en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
   ```sh
 
   kubectl delete -f .k8s/brpproxy-deployment.yaml \

--- a/docs/v2/getting-started.md
+++ b/docs/v2/getting-started.md
@@ -4,10 +4,10 @@ title: Getting Started
 ---
 # Getting Started
 
-Alle gemeenten en andere organisaties met een autorisatiebesluit conform artikel 38 van het Besluit BRP kunnen zich aanmelden voor deelname aan de pilot BRP.
+Alle gemeenten en andere organisaties met een autorisatiebesluit conform artikel 38 van het Besluit BRP kunnen zich aanmelden voor deelname aan het Experiment dataminimalisatie.
 
 1. Bekijk de [functionaliteit en specificaties](#functionaliteit-en-specificaties)
-2. Probeer en test de BRP API [lokaal](#probeer-en-test-de-api-lokaal) of in de [proef omgeving](#probeer-en-test-de-api-in-de-proef-omgeving)
+2. Probeer en test de {{ site.apiname }} [lokaal](#probeer-en-test-de-api-lokaal) of in de [proef omgeving](#probeer-en-test-de-api-in-de-proef-omgeving)
 3. [Download]({{ site.onboardingUrl }}){:target="_blank" rel="noopener"} en lees het onboardingproces
 
 ## Functionaliteit en specificaties
@@ -45,21 +45,21 @@ De volgende paragrafen beschrijven het installeren en aanroepen van de {{ site.a
 Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
 
 - [git](https://git-scm.com/downloads) voor het clonen van git repositories
-- [Postman](https://www.postman.com/downloads/) voor het aanroepen van Web API
+- [Postman](https://www.postman.com/downloads/) voor het aanroepen van {{ site.apiname }}
 
 
 ### Gebruik Docker als container engine
 
 - Download het [docker compose bestand]({{ site.devBranchUrl }}/docker-compose.yml){:target="_blank" rel="noopener"}
 - Start een command prompt window voor de map met het docker-compose.yaml bestand
-- Start de BRP API Personen en de mock met behulp van de volgende statement:
+- Start de {{ site.apiname }} en de mock met behulp van de volgende statement:
   ```sh
 
   docker-compose up -d
 
   ```
   De {{ site.apiname }} is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
-- Valideer dat de BRP API Personen en de mock draaien met behulp van de volgende curl statement:
+- Valideer dat de {{ site.apiname }} en de mock draaien met behulp van de volgende curl statement:
   ```sh
 
   curl --location --request POST 'http://localhost:5001/haalcentraal/api/brp/personen' \

--- a/docs/v2/getting-started.md
+++ b/docs/v2/getting-started.md
@@ -12,30 +12,30 @@ Alle gemeenten en andere organisaties met een autorisatiebesluit conform artikel
 
 ## Functionaliteit en specificaties
 
-De '{{ site.apiname }}' BRP API Personen is gespecificeerd met behulp van de [OpenAPI Specification v3.0.3](https://spec.openapis.org/oas/v3.0.3).
+De {{ site.apiname }} is gespecificeerd met behulp van de [OpenAPI Specification v3.0.3](https://spec.openapis.org/oas/v3.0.3).
 
-De OAS3 specificatie van de '{{ site.apiname }}' Web API kan worden bekeken met behulp van [Redoc](./redoc).
+De OAS3 specificatie van de {{ site.apiname }} kan worden bekeken met behulp van [Redoc](./redoc).
 
-Download de [OAS3 specificatie]({{ site.devBranchUrl }}/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"} van de '{{ site.apiname }}' Web API om hiermee consumer code te genereren.
+Download de [OAS3 specificatie]({{ site.devBranchUrl }}/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"} van de '{{ site.apiname }}' om hiermee consumer code te genereren.
 
-De [funtionele documentatie](./features-overzicht) van de '{{ site.apiname }}' Web API vindt je in de [features overzicht](./features-overzicht).
+De [funtionele documentatie](./features-overzicht) van de {{ site.apiname }} vindt je in de [features overzicht](./features-overzicht).
 
 ## Probeer en test de API in de proef omgeving
 
-De '{{ site.apiname }}' BRP API Personen kan worden geprobeerd via de proef omgeving met de volgende url: [{{ site.proefProxyUrl }}]. Hiervoor heb je een apikey nodig.
+De {{ site.apiname }} kan worden geprobeerd via de proef omgeving met de volgende url: [{{ site.proefProxyUrl }}]. Hiervoor heb je een apikey nodig.
 
 - Vraag een apikey aan bij de product owner [{{ site.PO-email }}](mailto:{{ site.PO-email }}). De apikey die is uitgereikt op de API Labs kan ook worden gebruikt.
 - Voeg de apikey toe aan een request met de __X-API-KEY__ header.
 
 ## Probeer en test de API lokaal
 
-De BRP API Personen is geïmplementeerd als een containerized applicatie, zodat het makkelijk kan worden getest op een lokale machine en worden gehost in een productie omgeving.
+De {{ site.apiname }} is geïmplementeerd als een containerized applicatie, zodat het makkelijk kan worden getest op een lokale machine en worden gehost in een productie omgeving.
 
-Het [docker compose bestand]({{ site.devBranchUrl }}/docker-compose.yml){:target="_blank" rel="noopener"} kan worden gebruikt om de BRP API Personen met behulp van [Docker Desktop](https://www.docker.com/products/docker-desktop) te draaien op een lokale machine.
+Het [docker compose bestand]({{ site.devBranchUrl }}/docker-compose.yml){:target="_blank" rel="noopener"} kan worden gebruikt om de {{ site.apiname }} met behulp van [Docker Desktop](https://www.docker.com/products/docker-desktop) te draaien op een lokale machine.
 
 In plaats van het docker compose bestand kunnen de [Kubernetes configuratie bestanden]({{ site.devBranchUrl}}/.k8s){:target="_blank" rel="noopener"} worden gebruikt om de API te draaien op een lokale machine. De API maakt gebruik van een mock met [testdataset persoonslijsten proefomgevingen GBA-V](https://www.rvig.nl/media/288) als input om de productie situatie zoveel mogelijk te kunnen simuleren.
 
-De volgende paragrafen beschrijven het installeren en aanroepen van de BRP API Personen op een lokale machine.
+De volgende paragrafen beschrijven het installeren en aanroepen van de {{ site.apiname }} op een lokale machine.
 
 ### Prerequisites
 
@@ -58,7 +58,7 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
   docker-compose up -d
 
   ```
-  De BRP API Personen is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
+  De {{ site.apiname }} is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
 - Valideer dat de BRP API Personen en de mock draaien met behulp van de volgende curl statement:
   ```sh
 
@@ -71,7 +71,7 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
   }'
 
   ```
-- Om de BRP API Personen en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
+- Om de {{ site.apiname }} en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
   ```sh
 
   docker-compose down
@@ -82,7 +82,7 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
 
 - Download de [kubernetes configuratie bestanden]({{ site.devBranchUrl }}/.k8s){:target="_blank" rel="noopener"}
 - Start een command prompt window voor de map met de kubernetes manifest bestanden
-- Start de BRP API Personen en de mock met behulp van de volgende statement:
+- Start de {{ site.apiname }} en de mock met behulp van de volgende statement:
   ```sh
 
   kubectl apply -f .k8s/brpproxy-deployment.yaml \
@@ -91,8 +91,8 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
                 -f .k8s/gbamock-service.yaml 
 
   ```
-  De BRP API Personen is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
-- Valideer dat de BRP API Personen en de mock draaien met behulp van de volgende curl statement:
+  De {{ site.apiname }} is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
+- Valideer dat de {{ site.apiname }} en de mock draaien met behulp van de volgende curl statement:
   ```sh
 
   curl --location --request POST 'http://localhost:5001/haalcentraal/api/brp/personen' \
@@ -104,7 +104,7 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
   }'
 
   ```
-- Om de BRP API Personen en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
+- Om de {{ site.apiname }} en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
   ```sh
 
   kubectl delete -f .k8s/brpproxy-deployment.yaml \

--- a/docs/v2/getting-started.md
+++ b/docs/v2/getting-started.md
@@ -16,7 +16,7 @@ De {{ site.apiname }} is gespecificeerd met behulp van de [OpenAPI Specification
 
 De OAS3 specificatie van de {{ site.apiname }} kan worden bekeken met behulp van [Redoc](./redoc).
 
-Download de [OAS3 specificatie]({{ site.devBranchUrl }}/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"} van de '{{ site.apiname }}' om hiermee consumer code te genereren.
+Download de [OAS3 specificatie]({{ site.mainBranchUrl }}/specificatie/genereervariant/openapi.yaml){:target="_blank" rel="noopener"} van de '{{ site.apiname }}' om hiermee consumer code te genereren.
 
 De [funtionele documentatie](./features-overzicht) van de {{ site.apiname }} vindt je in de [features overzicht](./features-overzicht).
 
@@ -29,13 +29,13 @@ De {{ site.apiname }} kan worden geprobeerd via de proef omgeving met de volgend
 
 ## Probeer en test de API lokaal
 
-De {{ site.apiname }} is geïmplementeerd als een containerized applicatie, zodat het makkelijk kan worden getest op een lokale machine en worden gehost in een productie omgeving.
+Een mock van de {{ site.apiname }} is beschikbaar als een containerized applicatie, zodat het makkelijk kan worden gehost op een lokale machine of in een test omgeving.
 
-Het [docker compose bestand]({{ site.devBranchUrl }}/docker-compose.yml){:target="_blank" rel="noopener"} kan worden gebruikt om de {{ site.apiname }} met behulp van [Docker Desktop](https://www.docker.com/products/docker-desktop) te draaien op een lokale machine.
+Het [docker compose bestand]({{ site.mainBranchUrl }}/docker-compose-mock.yml){:target="_blank" rel="noopener"} kan worden gebruikt om de {{ site.apiname }} mock met behulp van [Docker Desktop](https://www.docker.com/products/docker-desktop) te draaien op een lokale machine.
 
-In plaats van het docker compose bestand kunnen de [Kubernetes configuratie bestanden]({{ site.devBranchUrl}}/.k8s){:target="_blank" rel="noopener"} worden gebruikt om de API te draaien op een lokale machine. De API maakt gebruik van een mock met [testdataset persoonslijsten proefomgevingen GBA-V](https://www.rvig.nl/media/288) als input om de productie situatie zoveel mogelijk te kunnen simuleren.
+In plaats van het docker compose bestand kunnen de [Kubernetes configuratie bestanden]({{ site.devBranchUrl}}/.k8s){:target="_blank" rel="noopener"} worden gebruikt om de {{ site.apiname }} mock te draaien op een lokale machine. De {{ site.apiname }} mock maakt gebruik van de [testdataset persoonslijsten proefomgevingen GBA-V](https://www.rvig.nl/media/288) als input om de productie situatie zoveel mogelijk te kunnen simuleren.
 
-De volgende paragrafen beschrijven het installeren en aanroepen van de {{ site.apiname }} op een lokale machine.
+De volgende paragrafen beschrijven het installeren en aanroepen van de {{ site.apiname }} mock op een lokale machine.
 
 ### Prerequisites
 
@@ -50,16 +50,16 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
 
 ### Gebruik Docker als container engine
 
-- Download het [docker compose bestand]({{ site.devBranchUrl }}/docker-compose.yml){:target="_blank" rel="noopener"}
+- Download het [docker compose bestand]({{ site.mainBranchUrl }}/docker-compose.yml){:target="_blank" rel="noopener"}
 - Start een command prompt window voor de map met het docker-compose.yaml bestand
 - Start de {{ site.apiname }} en de mock met behulp van de volgende statement:
   ```sh
 
-  docker-compose up -d
+  docker-compose -f docker-compose-mock.yml up -d
 
   ```
-  De {{ site.apiname }} is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
-- Valideer dat de {{ site.apiname }} en de mock draaien met behulp van de volgende curl statement:
+  De {{ site.apiname }} mock is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
+- Valideer dat de {{ site.apiname }} mock draait met behulp van de volgende curl statement:
   ```sh
 
   curl --location --request POST 'http://localhost:5001/haalcentraal/api/brp/personen' \
@@ -71,10 +71,10 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
   }'
 
   ```
-- Om de {{ site.apiname }} en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
+- Om de {{ site.apiname }} mock container te stoppen moet de volgende statement worden uitgevoerd:
   ```sh
 
-  docker-compose down
+  docker-compose -f docker-compose-mock.yml down
 
   ```
 
@@ -85,14 +85,12 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
 - Start de {{ site.apiname }} en de mock met behulp van de volgende statement:
   ```sh
 
-  kubectl apply -f .k8s/brpproxy-deployment.yaml \
-                -f .k8s/brpproxy-service.yaml \
-                -f .k8s/gbamock-deployment.yaml \
-                -f .k8s/gbamock-service.yaml 
+  kubectl apply -f .k8s/brppersonenmock-deployment.yaml \
+                -f .k8s/brppersonenmock-service.yaml 
 
   ```
-  De {{ site.apiname }} is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
-- Valideer dat de {{ site.apiname }} en de mock draaien met behulp van de volgende curl statement:
+  De {{ site.apiname }} mock is nu te benaderen via de url: *http://localhost:5001/haalcentraal/api/brp/personen*
+- Valideer dat de {{ site.apiname }} mock draait met behulp van de volgende curl statement:
   ```sh
 
   curl --location --request POST 'http://localhost:5001/haalcentraal/api/brp/personen' \
@@ -104,12 +102,10 @@ Optioneel kan de volgende tools ook op de lokale machine worden geïnstalleerd
   }'
 
   ```
-- Om de {{ site.apiname }} en de mock containers te stoppen moet de volgende statement worden uitgevoerd:
+- Om de {{ site.apiname }} mock container te stoppen moet de volgende statement worden uitgevoerd:
   ```sh
 
-  kubectl delete -f .k8s/brpproxy-deployment.yaml \
-                 -f .k8s/brpproxy-service.yaml \
-                 -f .k8s/gbamock-deployment.yaml \
-                 -f .k8s/gbamock-service.yaml 
+  kubectl delete -f .k8s/brppersonenmock-deployment.yaml \
+                 -f .k8s/brppersonenmock-service.yaml 
 
   ```


### PR DESCRIPTION
De inhoud van de links moet nog wel worden gewijzigd:
- API bijna overal BRP API Personen genoemd
- onderscheid proxy en gba variant verwijderd.
- mock is nu een mock van de proefomgeving testgevallen