### PR TITLE
correcties in openapi specificaties

### DIFF
--- a/specificatie/brp-api/gezag/derde-v1.yaml
+++ b/specificatie/brp-api/gezag/derde-v1.yaml
@@ -31,3 +31,4 @@ components:
     OnbekendeDerde:
       allOf:
         - $ref: '#/components/schemas/Derde'
+        - type: object

--- a/specificatie/brp-api/overlijden/overlijden-v1.yaml
+++ b/specificatie/brp-api/overlijden/overlijden-v1.yaml
@@ -7,14 +7,14 @@ components:
     Overlijden:
       allOf: 
         - $ref: '../../brp/overlijden/overlijden-basis-v1.yaml#/components/schemas/OverlijdenBasis'
-      type: object
-      properties:
-        datum:
-          description: |
-            datum waarop de persoon is overleden.
-          $ref: '../datum/datum-polymorf-v1.yaml#/components/schemas/AbstractDatum'
-        inOnderzoek:
-          $ref: '#/components/schemas/OverlijdenInOnderzoek'
+        - type: object
+          properties:
+            datum:
+              description: |
+                datum waarop de persoon is overleden.
+              $ref: '../datum/datum-polymorf-v1.yaml#/components/schemas/AbstractDatum'
+            inOnderzoek:
+              $ref: '#/components/schemas/OverlijdenInOnderzoek'
     OverlijdenInOnderzoek:
       description: |
         Geeft aan welke gegevens over het overlijden van de persoon in onderzoek zijn.

--- a/specificatie/brp/gezag/derde-v1.yaml
+++ b/specificatie/brp/gezag/derde-v1.yaml
@@ -33,3 +33,4 @@ components:
     OnbekendeDerde:
       allOf:
         - $ref: '#/components/schemas/Derde'
+        - type: object

--- a/specificatie/resolved/openapi.json
+++ b/specificatie/resolved/openapi.json
@@ -1508,18 +1508,20 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/OverlijdenBasis"
-          }
-        ],
-        "type": "object",
-        "properties": {
-          "datum": {
-            "description": "datum waarop de persoon is overleden.\n",
-            "$ref": "#/components/schemas/AbstractDatum"
           },
-          "inOnderzoek": {
-            "$ref": "#/components/schemas/OverlijdenInOnderzoek"
+          {
+            "type": "object",
+            "properties": {
+              "datum": {
+                "description": "datum waarop de persoon is overleden.\n",
+                "$ref": "#/components/schemas/AbstractDatum"
+              },
+              "inOnderzoek": {
+                "$ref": "#/components/schemas/OverlijdenInOnderzoek"
+              }
+            }
           }
-        }
+        ]
       },
       "AbstractVerblijfplaats": {
         "type": "object",
@@ -2232,6 +2234,9 @@
         "allOf": [
           {
             "$ref": "#/components/schemas/Derde"
+          },
+          {
+            "type": "object"
           }
         ]
       },

--- a/specificatie/resolved/openapi.yaml
+++ b/specificatie/resolved/openapi.yaml
@@ -1026,14 +1026,14 @@ components:
     Overlijden:
       allOf:
         - $ref: '#/components/schemas/OverlijdenBasis'
-      type: object
-      properties:
-        datum:
-          description: |
-            datum waarop de persoon is overleden.
-          $ref: '#/components/schemas/AbstractDatum'
-        inOnderzoek:
-          $ref: '#/components/schemas/OverlijdenInOnderzoek'
+        - type: object
+          properties:
+            datum:
+              description: |
+                datum waarop de persoon is overleden.
+              $ref: '#/components/schemas/AbstractDatum'
+            inOnderzoek:
+              $ref: '#/components/schemas/OverlijdenInOnderzoek'
     AbstractVerblijfplaats:
       type: object
       description: |
@@ -1495,6 +1495,7 @@ components:
     OnbekendeDerde:
       allOf:
         - $ref: '#/components/schemas/Derde'
+        - type: object
     GezamenlijkGezag:
       allOf:
         - $ref: '#/components/schemas/Gezagsrelatie'


### PR DESCRIPTION
- de OnbekendeDerde type is uitgebreid tbv code generatie. De object type is toegevoegd in de allOf property van OnbekendeDerde zodat de OnbekendeDerde class wordt gegenereerd bij codegeneratie met NSwag
- het inspringen van het inline embedded object is gecorrigeerd

@FrozenSync, wordt er correct code gegenereerd als de OnbekendeDerde aanpassing ook wordt doorgevoerd in de gezag-app?

fixes #1971 